### PR TITLE
Fix FDA dist

### DIFF
--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -2,10 +2,6 @@ import org.labkey.gradle.task.ModuleDistribution
 import org.labkey.gradle.util.BuildUtils
 import org.labkey.gradle.util.GroupNames
 
-plugins {
-    id 'org.labkey.build.distribution'
-}
-
 buildscript {
     repositories {
         maven {
@@ -15,6 +11,10 @@ buildscript {
     dependencies {
         classpath "org.labkey.build:gradlePlugins:${gradlePluginsVersion}"
     }
+}
+
+plugins {
+    id 'org.labkey.build.distribution'
 }
 
 BuildUtils.addModuleDistributionDependencies(project, [BuildUtils.getApiProjectPath(project.gradle),


### PR DESCRIPTION
#### Rationale
`distributions/fda/build.gradle` is improperly structured. Attempting to build the FDA distribution results in an error like:
```
build file '/mnt/teamcity/work/8a2caed6a264a11/server/modules/Response/distributions/fda/build.gradle': 9: all buildscript {} blocks must appear before any plugins {} blocks in the script
```

#### Changes
* Pull `buildscript` block to the top of the file
