### PR TITLE
Add visualization module to distribution

### DIFF
--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -23,10 +23,11 @@ BuildUtils.addModuleDistributionDependencies(project, [BuildUtils.getApiProjectP
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "core"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "filecontent"),
+                                                       BuildUtils.getPlatformModuleProjectPath(project.gradle, "list"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "pipeline"),
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "query"),
                                                        ":server:modules:Response",
-                                                       BuildUtils.getPlatformModuleProjectPath(project.gradle, "list")])
+                                                       BuildUtils.getPlatformModuleProjectPath(project.gradle, "visualization")])
 
 project.task(
         "distribution",


### PR DESCRIPTION
#### Rationale
The domain designer redesign accidentally introduced a dependency on the visualization module. Adding to distribution to prevent runtime errors when visiting domain designers.

#### Changes
* Add visualization module to 'fda' distribution.
