### PR TITLE
Update approach for removing user foreign keys

### DIFF
--- a/src/org/labkey/response/query/ReadResponsesQuerySchema.java
+++ b/src/org/labkey/response/query/ReadResponsesQuerySchema.java
@@ -22,7 +22,6 @@ import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ForeignKey;
-import org.labkey.api.data.MutableColumnInfo;
 import org.labkey.api.data.SimpleFilter;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
@@ -145,15 +144,13 @@ public class ReadResponsesQuerySchema extends UserSchema
         private static final Set<String> NAUGHTY_COLUMNS = Sets.newCaseInsensitiveHashSet("CreatedBy", "ModifiedBy", "Container");
 
         @Override
-        public MutableColumnInfo addWrapColumn(ColumnInfo column)
+        public void afterConstruct()
         {
-            var wrapped = super.addWrapColumn(column);
+            super.afterConstruct();
 
             // Nuke standard columns that have foreign keys to other schemas... otherwise, selectRows and executeSql would blow up when these columns are selected
-            if (NAUGHTY_COLUMNS.contains(wrapped.getColumnName()))
-                wrapped.setFk((ForeignKey)null);
-
-            return wrapped;
+            for (var columnName : NAUGHTY_COLUMNS)
+                getMutableColumn(columnName).setFk((ForeignKey) null);
         }
 
         @Override


### PR DESCRIPTION
#### Rationale
We're now using ConceptURIs to denote standard columns like user IDs. As a result, we had to update our approach for blanking out user FKs in the special read responses query schema.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/2121