### PR TITLE
Fix potential concurrency issue during ResponseSubmissionTest

### DIFF
--- a/src/org/labkey/response/ResponseManager.java
+++ b/src/org/labkey/response/ResponseManager.java
@@ -38,6 +38,7 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListItem;
@@ -841,7 +842,14 @@ public class ResponseManager
         if (user != null && !user.isGuest())
             response.setProcessedBy(user);
 
-        Table.update(user, responseTable, response, response.getRowId());
+        try
+        {
+            Table.update(user, responseTable, response, response.getRowId());
+        }
+        catch (OptimisticConflictException e)
+        {
+            //Ignore the error, we already deleted the survey response so we don't need to perform the update
+        }
     }
 
     public Set<Integer> getNonErrorResponses(Set<Integer> listIds)

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -48,6 +48,8 @@ public class ResponseSubmissionTest extends BaseResponseTest
     @Override
     void setupProjects()
     {
+        doCleanup(false);
+
         setupProject(STUDY_NAME01, PROJECT_NAME01, SURVEY_NAME, false);
         setupProject(STUDY_NAME02, PROJECT_NAME02, SURVEY_NAME, true);
         setSurveyMetadataDropDir();
@@ -259,6 +261,9 @@ public class ResponseSubmissionTest extends BaseResponseTest
         assertTrue("Submission failed, expected success", cmd.getSuccess());
         log("successful submission to " + STUDY_NAME03);
 
+        // Verify response was processed prior to deleting container as a Concurrency violation may occur
+        goToManageLists().getGrid().viewListHistory(SURVEY_NAME);
+        waitForText("A new list record was inserted");
         _containerHelper.deleteProject(PROJECT_NAME03, false);
 
         //        9. Check submission to deleted project
@@ -269,5 +274,14 @@ public class ResponseSubmissionTest extends BaseResponseTest
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+
+        _containerHelper.deleteProject(PROJECT_NAME01, false);
+        _containerHelper.deleteProject(PROJECT_NAME02, false);
     }
 }

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -261,9 +261,6 @@ public class ResponseSubmissionTest extends BaseResponseTest
         assertTrue("Submission failed, expected success", cmd.getSuccess());
         log("successful submission to " + STUDY_NAME03);
 
-        // Verify response was processed prior to deleting container as a Concurrency violation may occur
-        goToManageLists().getGrid().viewListHistory(SURVEY_NAME);
-        waitForText("A new list record was inserted");
         _containerHelper.deleteProject(PROJECT_NAME03, false);
 
         //        9. Check submission to deleted project


### PR DESCRIPTION
Catch and ignore OptimisticConflictException during survey response processing status update when the underlying Response is deleted. Chose to catch the error as I couldn't see a good way to avoid the 0 results check in the Table.update method.

#### Rationale
Fix test failure

#### Changes
* Add a try/catch around the status update to catch and ignore the error.
* Add some test cleanup to ResponseSubmissionTest that was missing
