### PR TITLE
Backport OptimisticConflictException handling to 21.3

### DIFF
--- a/src/org/labkey/response/ResponseManager.java
+++ b/src/org/labkey/response/ResponseManager.java
@@ -38,6 +38,7 @@ import org.labkey.api.data.SqlSelector;
 import org.labkey.api.data.Table;
 import org.labkey.api.data.TableInfo;
 import org.labkey.api.data.TableSelector;
+import org.labkey.api.exceptions.OptimisticConflictException;
 import org.labkey.api.exp.ObjectProperty;
 import org.labkey.api.exp.list.ListDefinition;
 import org.labkey.api.exp.list.ListItem;
@@ -841,7 +842,14 @@ public class ResponseManager
         if (user != null && !user.isGuest())
             response.setProcessedBy(user);
 
-        Table.update(user, responseTable, response, response.getRowId());
+        try
+        {
+            Table.update(user, responseTable, response, response.getRowId());
+        }
+        catch (OptimisticConflictException e)
+        {
+            //Ignore the error, we already deleted the survey response so we don't need to perform the update
+        }
     }
 
     public Set<Integer> getNonErrorResponses(Set<Integer> listIds)

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -48,6 +48,8 @@ public class ResponseSubmissionTest extends BaseResponseTest
     @Override
     void setupProjects()
     {
+        doCleanup(false);
+
         setupProject(STUDY_NAME01, PROJECT_NAME01, SURVEY_NAME, false);
         setupProject(STUDY_NAME02, PROJECT_NAME02, SURVEY_NAME, true);
         setSurveyMetadataDropDir();
@@ -269,5 +271,14 @@ public class ResponseSubmissionTest extends BaseResponseTest
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
+    }
+
+    @Override
+    protected void doCleanup(boolean afterTest)
+    {
+        super.doCleanup(afterTest);
+
+        _containerHelper.deleteProject(PROJECT_NAME01, false);
+        _containerHelper.deleteProject(PROJECT_NAME02, false);
     }
 }


### PR DESCRIPTION
Backport of changes from https://github.com/FDA-MyStudies/Response/pull/9

Catch and ignore OptimisticConflictException during survey response processing status update when the underlying Response is deleted.
