### PR TITLE
Make response distribution embedded

### DIFF
--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -27,5 +27,6 @@ project.task(
             dist.includeTarGZArchive=true
             dist.extraFileIdentifier='-response'
             dist.simpleDistribution=true
+            dist.embeddedArchiveType='tar.gz'
         }
 )

--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -24,6 +24,7 @@ project.task(
         type: ModuleDistribution,
         {ModuleDistribution dist ->
             dist.subDirName='response'
+            dist.includeTarGZArchive=true
             dist.extraFileIdentifier='-response'
             dist.simpleDistribution=true
             dist.embeddedArchiveType='tar.gz'

--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -24,7 +24,6 @@ project.task(
         type: ModuleDistribution,
         {ModuleDistribution dist ->
             dist.subDirName='response'
-            dist.includeTarGZArchive=true
             dist.extraFileIdentifier='-response'
             dist.simpleDistribution=true
             dist.embeddedArchiveType='tar.gz'

--- a/distributions/fda/gradle.properties
+++ b/distributions/fda/gradle.properties
@@ -1,1 +1,2 @@
 isOpenSource=true
+useEmbeddedTomcat

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.29.0_embeddedStandalone-SNAPSHOT
+gradlePluginsVersion=1.29.0
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 apacheTomcatVersion=8.5.51

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.27.0
+gradlePluginsVersion=1.29.0_embeddedStandalone-SNAPSHOT
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
 apacheTomcatVersion=8.5.51

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,6 +41,5 @@ gradle.beforeProject { project ->
             url "${project.artifactory_contextUrl}/libs-snapshot"
         }
         mavenCentral()
-        mavenLocal()
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -41,5 +41,6 @@ gradle.beforeProject { project ->
             url "${project.artifactory_contextUrl}/libs-snapshot"
         }
         mavenCentral()
+        mavenLocal()
     }
 }


### PR DESCRIPTION
#### Rationale
Distributions that embed tomcat have fewer external dependencies to manage, simplifying manual and automated deployment process.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/128

#### Changes
* Update response distribution to contain embedded Tomcat