### PR TITLE
Update standalone version to 21.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,6 @@
 gradlePluginsVersion=1.29.0
 artifactory_contextUrl=https://artifactory.labkey.com/artifactory
 
-apacheTomcatVersion=8.5.51
-labkeyClientApiVersion=1.3.2
+apacheTomcatVersion=8.5.69
+labkeyClientApiVersion=1.4.0
 servletApiVersion=3.0

--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
     // Properties for standalone build.
     // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "21.3-SNAPSHOT"
+        labkeyVersion = "21.7-SNAPSHOT"
 
         buildFromSource = true
 


### PR DESCRIPTION
#### Rationale
MyStudies development is synced to LabKey ESR releases. Standalone builds should work with 21.7.