### PR TITLE
Issue 43689: Wording of success messages

### DIFF
--- a/src/org/labkey/response/view/MyStudiesResponseServerSettings.jsp
+++ b/src/org/labkey/response/view/MyStudiesResponseServerSettings.jsp
@@ -160,9 +160,9 @@
 </labkey:panel>
 
 <script type="text/javascript">
-    let pulseSuccessMessage = () => {
+    let pulseSuccessMessage = (message) => {
         let successMessage = $('.lk-response-update-metadata-success');
-        successMessage.text("Configuration Saved");
+        successMessage.text(message);
         successMessage.fadeIn(3000).delay(3000).fadeOut("slow");
     }
 
@@ -184,7 +184,7 @@
                 $('#submitStudySetupButton').addClass("labkey-disabled-button");
                 $('#updateMetadataButton').removeClass("labkey-disabled-button");
 
-                pulseSuccessMessage();
+                pulseSuccessMessage("Configuration Saved");
             },
             failure: (response) => {
                 let errorMessage = "There was a problem.  Please check the logs or contact an administrator.";
@@ -222,7 +222,7 @@
             url: LABKEY.ActionURL.buildURL("response", "UpdateStudyMetadata"),
             method: 'POST',
             jsonData: { studyId: $('#studyId').val() },
-            success: (r) => { pulseSuccessMessage(); },
+            success: (r) => { pulseSuccessMessage("Metadata Updated"); },
             failure: (r) => {
                 LABKEY.Utils.alert("Error", "There was a problem updating the study metadata.  Please check the logs or contact an administrator.");
             }

--- a/test/src/org/labkey/test/components/response/MyStudiesResponseServerTab.java
+++ b/test/src/org/labkey/test/components/response/MyStudiesResponseServerTab.java
@@ -152,7 +152,7 @@ public class MyStudiesResponseServerTab extends LabKeyPage<MyStudiesResponseServ
     public void saveAndExpectSuccess()
     {
         saveStudySetup();
-        shortWait().until(ExpectedConditions.visibilityOf(elementCache().successMessage));
+        shortWait().until(ExpectedConditions.visibilityOf(elementCache().successSaveMessage));
     }
 
     public void clickUpdateMetadata()
@@ -162,7 +162,7 @@ public class MyStudiesResponseServerTab extends LabKeyPage<MyStudiesResponseServ
 
         elementCache().updateMetadata.click();
 
-        shortWait().until(ExpectedConditions.visibilityOf(elementCache().successMessage));
+        shortWait().until(ExpectedConditions.visibilityOf(elementCache().successUpdateMessage));
     }
 
     private boolean isUpdateMetadataEnabled()
@@ -192,7 +192,8 @@ public class MyStudiesResponseServerTab extends LabKeyPage<MyStudiesResponseServ
         Checkbox responseCollection = new Checkbox(Locator.checkboxById("responseCollection").findWhenNeeded(getDriver()));
         WebElement saveStudySetup = new LazyWebElement(Locator.lkButton("Save"),this);
         WebElement updateMetadata = new LazyWebElement(Locator.lkButton("Update Metadata"),this);
-        WebElement successMessage = Locator.tagWithText("span", "Configuration Saved").findWhenNeeded(this);
+        WebElement successSaveMessage = Locator.tagWithText("span", "Configuration Saved").findWhenNeeded(this);
+        WebElement successUpdateMessage = Locator.tagWithText("span", "Metadata Updated").findWhenNeeded(this);
 
         OAuthWebPart oAuthWebPart = new OAuthWebPart(getDriver(), new LazyWebElement(Locator.id("oauthPanel"), this));
         BasicAuthWebPart basicAuthWebPart = new BasicAuthWebPart(getDriver(), new LazyWebElement(Locator.id("basicAuthPanel"), this));


### PR DESCRIPTION
#### Rationale
Previously, clicking either the "Update Metadata" button or the "Save" button on the "Folder Management > MyStudies Response Server" page would result in a "Configuration Saved" message. Now we will display a "Configuration Saved" or "Metadata Updated" message depending on which button was clicked.

#### Related Pull Requests
* https://github.com/FDA-MyStudies/Response/pull/32

#### Changes
* Update jsp JS
* Update tests
