### PR TITLE
Spanish language support

### DIFF
--- a/resources/schemas/dbscripts/postgresql/mobileappstudy-21.001-21.002.sql
+++ b/resources/schemas/dbscripts/postgresql/mobileappstudy-21.001-21.002.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mobileappstudy.Response ADD COLUMN Language VARCHAR(100);

--- a/src/org/labkey/response/ResponseController.java
+++ b/src/org/labkey/response/ResponseController.java
@@ -281,7 +281,8 @@ public class ResponseController extends SpringActionController
                     form.getParticipantId(),
                     form.getData().toString(),
                     form.getMetadata().getActivityId(),
-                    form.getMetadata().getVersion()
+                    form.getMetadata().getVersion(),
+                    form.getMetadata().getLanguage()
             );
             resp = manager.insertResponse(resp);
 
@@ -1182,12 +1183,6 @@ public class ResponseController extends SpringActionController
             // Or, if you prefer, you could put the modules you want in Set.of().
             c.setActiveModules(Set.of());
             c.setFolderType(FolderTypeManager.get().getFolderType("Mobile App Study"), getUser());
-
-            // An example of setting a module property -- in this case, to an invalid value
-            Module module = ModuleLoader.getInstance().getModule(ResponseModule.NAME);
-            Map<String, ModuleProperty> props = module.getModuleProperties();
-            ModuleProperty mp = props.get(ResponseModule.METADATA_SERVICE_BASE_URL);
-            mp.saveValue(getUser(), getContainer(), "This is a test");
 
             return success();
         }

--- a/src/org/labkey/response/ResponseController.java
+++ b/src/org/labkey/response/ResponseController.java
@@ -72,6 +72,7 @@ import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
 import org.labkey.api.view.ViewContext;
 import org.labkey.response.data.EnrollmentTokenBatch;
+import org.labkey.response.data.Language;
 import org.labkey.response.data.MobileAppStudy;
 import org.labkey.response.data.Participant;
 import org.labkey.response.data.SurveyMetadata;
@@ -351,7 +352,9 @@ public class ResponseController extends SpringActionController
                 // we allow for the possibility that someone can enroll without using an enrollment token
                 else if (ResponseManager.get().enrollmentTokenRequired(form.getShortName()))
                 {
-                    errors.reject(ERROR_REQUIRED, "Token is required");
+                    // Return the "Token is required" error message in the requested language
+                    Language lang = Language.getLanguage(form.getLanguage());
+                    errors.reject(ERROR_REQUIRED, lang.getTokenIsRequiredErrorMessage());
                 }
             }
         }
@@ -711,6 +714,7 @@ public class ResponseController extends SpringActionController
         private String _token;
         private String _shortName;
         private String _allowDataSharing;
+        private String _language;
 
         public String getToken()
         {
@@ -754,6 +758,16 @@ public class ResponseController extends SpringActionController
         public void setAllowDataSharing(String allowDataSharing)
         {
             _allowDataSharing = allowDataSharing;
+        }
+
+        public String getLanguage()
+        {
+            return _language;
+        }
+
+        public void setLanguage(String language)
+        {
+            _language = language;
         }
     }
 

--- a/src/org/labkey/response/ResponseModule.java
+++ b/src/org/labkey/response/ResponseModule.java
@@ -49,9 +49,6 @@ import java.util.function.Predicate;
 public class ResponseModule extends DefaultModule
 {
     public static final String NAME = "Response";
-    public static final String SURVEY_METADATA_DIRECTORY = "SurveyMetadataDirectory";
-    public static final String METADATA_SERVICE_BASE_URL = "MetadataServiceBaseUrl";
-    public static final String METADATA_SERVICE_ACCESS_TOKEN = "MetadataServiceAccessToken";
 
     /**
      * Predicate that can be used to check if a container has this module active
@@ -67,7 +64,7 @@ public class ResponseModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 21.001;
+        return 21.002;
     }
 
     @Override

--- a/src/org/labkey/response/data/Language.java
+++ b/src/org/labkey/response/data/Language.java
@@ -1,0 +1,66 @@
+package org.labkey.response.data;
+
+import com.google.common.base.Enums;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public enum Language
+{
+    // Language codes and names sourced from https://developer.box.com/guides/api-calls/language-codes/
+    bn("Bengali"),
+    da("Danish"),
+    de("German"),
+    en("English (US)"),
+    gb("English (UK)"),
+    e2("English (Canada)"),
+    e3("English (Australia)"),
+    s2("Spanish (Latin America)"),
+    es("Spanish")
+        {
+            @Override
+            public String getTokenIsRequiredErrorMessage()
+            {
+                return "Se requiere un token";
+            }
+        },
+    fi("Finnish"),
+    fr("French"),
+    f2("French (Canada)"),
+    hi("Hindi"),
+    it("Italian"),
+    ja("Japanese"),
+    ko("Korean"),
+    nb("Norwegian (Bokmal)"),
+    nl("Dutch"),
+    pl("Polish"),
+    pt("Portuguese"),
+    ru("Russian"),
+    sv("Swedish"),
+    tr("Turkish"),
+    zh("Chinese (Simplified)"),
+    zt("Chinese (Traditional)");
+
+    private final String _friendlyName;
+
+    Language(String friendlyName)
+    {
+        _friendlyName = friendlyName;
+    }
+
+    public String getFriendlyName()
+    {
+        return _friendlyName;
+    }
+
+    // Default to English; override to provide translation
+    public String getTokenIsRequiredErrorMessage()
+    {
+        return "Token is required";
+    }
+
+    // Return a Language enum constant given a two-character code. Null or unknown code default to US English (en).
+    public static @NotNull Language getLanguage(@Nullable String code)
+    {
+        return null != code ? Enums.getIfPresent(Language.class, code).or(Language.en) : Language.en;
+    }
+}

--- a/src/org/labkey/response/data/SurveyMetadata.java
+++ b/src/org/labkey/response/data/SurveyMetadata.java
@@ -27,7 +27,7 @@ public class SurveyMetadata
     private String _activityId;
     private String _version;
     private String _studyVersion;
-    private Language _language;
+    private Language _language = Language.en;  // Default to English if not provided
 
     public String getVersion()
     {

--- a/src/org/labkey/response/data/SurveyMetadata.java
+++ b/src/org/labkey/response/data/SurveyMetadata.java
@@ -27,6 +27,7 @@ public class SurveyMetadata
     private String _activityId;
     private String _version;
     private String _studyVersion;
+    private Language _language;
 
     public String getVersion()
     {
@@ -60,9 +61,20 @@ public class SurveyMetadata
     {
         return _studyVersion;
     }
-
     public void setStudyVersion(String studyVersion)
     {
         _studyVersion = studyVersion;
+    }
+
+    // Note: inconsistent with setter: returns friendly name for storage
+    public String getLanguage()
+    {
+        return _language.getFriendlyName();
+    }
+
+    // Note: inconsistent with getter: expects a two-character code
+    public void setLanguage(String code)
+    {
+        _language = Language.getLanguage(code);
     }
 }

--- a/src/org/labkey/response/data/SurveyResponse.java
+++ b/src/org/labkey/response/data/SurveyResponse.java
@@ -57,6 +57,7 @@ public class SurveyResponse
     private Integer _participantId;
     private String _surveyVersion;
     private String _activityId;
+    private String _language;
     private ResponseStatus _status;
     private Date _processed;
     private User _processedBy;
@@ -69,13 +70,14 @@ public class SurveyResponse
     {
     }
 
-    public SurveyResponse(String participantId, String data, String activityId, String version)
+    public SurveyResponse(String participantId, String data, String activityId, String version, String language)
     {
         setStatus(SurveyResponse.ResponseStatus.PENDING);
         setAppToken(participantId);
         setData(data);
         setSurveyVersion(version);
         setActivityId(activityId);
+        setLanguage(language);
     }
 
     public Container getContainer()
@@ -170,6 +172,16 @@ public class SurveyResponse
     public void setParticipantId(Integer participantId)
     {
         _participantId = participantId;
+    }
+
+    public String getLanguage()
+    {
+        return _language;
+    }
+
+    public void setLanguage(String language)
+    {
+        _language = language;
     }
 
     public String getData()

--- a/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.commands.response;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.json.simple.JSONObject;
@@ -23,7 +22,6 @@ import org.labkey.test.WebTestHelper;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 
 public class EnrollParticipantCommand extends ResponseCommand
@@ -47,14 +45,12 @@ public class EnrollParticipantCommand extends ResponseCommand
         _projectName = projectName;
     }
 
-    public EnrollParticipantCommand(String project, String studyName, String batchToken, String allowDataSharing, Consumer<String> logger)
+    public EnrollParticipantCommand(String project, String studyName, String batchToken, String allowDataSharing)
     {
         _studyName = studyName;
         _batchToken = batchToken;
         _projectName = project;
         _allowDataSharing = allowDataSharing;
-
-        setLogger(logger);
     }
 
     public String getStudyName()
@@ -97,8 +93,7 @@ public class EnrollParticipantCommand extends ResponseCommand
     {
         Map<String, String> params = new HashMap<>();
         params.put("studyId", getStudyName());
-        if (StringUtils.isNotBlank(getBatchToken()))
-            params.put("token", getBatchToken());
+        params.put("token", getBatchToken());
         params.put("allowDataSharing", getAllowDataSharing());
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }

--- a/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
@@ -27,7 +27,6 @@ import java.util.Map;
 public class EnrollParticipantCommand extends ResponseCommand
 {
     private static final String APP_TOKEN_JSON_FIELD = "appToken";
-    protected static final String CONTROLLER_NAME = ResponseCommand.CONTROLLER_NAME;
     protected static final String ACTION_NAME = "enroll";
 
     private String _batchToken;
@@ -35,6 +34,7 @@ public class EnrollParticipantCommand extends ResponseCommand
     private String _appToken;
     private String _projectName;
     private String _allowDataSharing;
+    private String _language;
 
     public String getProjectName()
     {
@@ -81,6 +81,16 @@ public class EnrollParticipantCommand extends ResponseCommand
         _allowDataSharing = allowDataSharing;
     }
 
+    public String getLanguage()
+    {
+        return _language;
+    }
+
+    public void setLanguage(String language)
+    {
+        _language = language;
+    }
+
     @Override
     public HttpResponse execute(int expectedStatusCode)
     {
@@ -95,6 +105,10 @@ public class EnrollParticipantCommand extends ResponseCommand
         params.put("studyId", getStudyName());
         params.put("token", getBatchToken());
         params.put("allowDataSharing", getAllowDataSharing());
+        if (getLanguage() != null)
+        {
+            params.put("language", getLanguage());
+        }
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
@@ -16,7 +16,6 @@
 package org.labkey.test.commands.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.json.simple.JSONObject;
@@ -100,8 +99,7 @@ public class EnrollmentTokenValidationCommand extends ResponseCommand
     {
         Map<String, String> params = new HashMap<>();
         params.put("studyId", getStudyName());
-        if (StringUtils.isNotBlank(getBatchToken()))
-            params.put("token", getBatchToken());
+        params.put("token", getBatchToken());
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
@@ -40,6 +40,7 @@ public class EnrollmentTokenValidationCommand extends ResponseCommand
     private String _batchToken;
     private String _studyName;
     private String _projectName;
+    private String _language;
 
     private Collection<ParticipantProperty> _preEnrollmentParticipantProperties;
 
@@ -87,6 +88,16 @@ public class EnrollmentTokenValidationCommand extends ResponseCommand
         _batchToken = batchToken;
     }
 
+    public String getLanguage()
+    {
+        return _language;
+    }
+
+    public void setLanguage(String language)
+    {
+        _language = language;
+    }
+
     @Override
     public HttpResponse execute(int expectedStatusCode)
     {
@@ -100,6 +111,10 @@ public class EnrollmentTokenValidationCommand extends ResponseCommand
         Map<String, String> params = new HashMap<>();
         params.put("studyId", getStudyName());
         params.put("token", getBatchToken());
+        if (getLanguage() != null)
+        {
+            params.put("language", getLanguage());
+        }
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollmentTokenValidationCommand.java
@@ -28,12 +28,10 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 
 public class EnrollmentTokenValidationCommand extends ResponseCommand
 {
-    protected static final String CONTROLLER_NAME = ResponseCommand.CONTROLLER_NAME;
     protected static final String ACTION_NAME = "validateenrollmenttoken";
     public static final String INVALID_STUDYID_FORMAT = "Study with StudyId '%1$s' does not exist";
     public static final String INVALID_TOKEN_FORMAT = "Invalid token: '%1$s'";
@@ -65,13 +63,11 @@ public class EnrollmentTokenValidationCommand extends ResponseCommand
         _projectName = projectName;
     }
 
-    public EnrollmentTokenValidationCommand(String project, String studyName, String batchToken, Consumer<String> logger)
+    public EnrollmentTokenValidationCommand(String project, String studyName, String batchToken)
     {
         _studyName = studyName;
         _batchToken = batchToken;
         _projectName = project;
-
-        setLogger(logger);
     }
 
     public String getStudyName()

--- a/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
@@ -26,7 +26,6 @@ import org.labkey.test.data.response.ResolveEnrollmentTokenResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 
 public class ResolveEnrollmentTokenCommand extends ResponseCommand
@@ -49,12 +48,10 @@ public class ResolveEnrollmentTokenCommand extends ResponseCommand
         _projectName = projectName;
     }
 
-    public ResolveEnrollmentTokenCommand(String project, String batchToken, Consumer<String> logger)
+    public ResolveEnrollmentTokenCommand(String project, String batchToken)
     {
         _batchToken = batchToken;
         _projectName = project;
-
-        setLogger(logger);
     }
 
     public String getBatchToken()

--- a/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
@@ -29,7 +29,6 @@ import java.util.Map;
 
 public class ResolveEnrollmentTokenCommand extends ResponseCommand
 {
-    protected static final String CONTROLLER_NAME = ResponseCommand.CONTROLLER_NAME;
     protected static final String ACTION_NAME = "resolveenrollmenttoken";
 
     private String _batchToken;

--- a/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
+++ b/test/src/org/labkey/test/commands/response/ResolveEnrollmentTokenCommand.java
@@ -16,7 +16,6 @@
 package org.labkey.test.commands.response;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.json.simple.JSONObject;
@@ -84,8 +83,7 @@ public class ResolveEnrollmentTokenCommand extends ResponseCommand
     public String getTargetURL()
     {
         Map<String, String> params = new HashMap<>();
-        if (StringUtils.isNotBlank(getBatchToken()))
-            params.put("token", getBatchToken());
+        params.put("token", getBatchToken());
         return WebTestHelper.buildURL(CONTROLLER_NAME, getProjectName(), ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/response/ResponseCommand.java
+++ b/test/src/org/labkey/test/commands/response/ResponseCommand.java
@@ -24,9 +24,9 @@ import org.apache.http.util.EntityUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import org.labkey.test.util.TestLogger;
 
 import java.io.IOException;
-import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
 
@@ -61,7 +61,6 @@ public abstract class ResponseCommand
         _exceptionMessage = exceptionMessage;
     }
 
-    private Consumer<String> logger;
     protected boolean isExecuted = false;
     protected JSONObject _jsonResponse;
 
@@ -97,34 +96,24 @@ public abstract class ResponseCommand
         setExceptionMessage((String) response.get(EXCEPTION_MESSAGE_TAG));
     }
 
-    public void log(String text)
-    {
-        logger.accept(text);
-    }
-
-    public void setLogger(Consumer<String> logger)
-    {
-        this.logger = logger;
-    }
-
     protected HttpResponse execute(HttpUriRequest request, int expectedStatusCode)
     {
         setExceptionMessage(null); // Clear out previous exception message, in case we're reusing this Command
         HttpResponse response = null;
-        log("Submitting request using url: " + request.getURI());
+        TestLogger.log("Submitting request using url: " + request.getURI());
 
         try (CloseableHttpClient client = HttpClients.createDefault())
         {
             response = client.execute(request);
             isExecuted = true;
-            log("Post completed. Response body: " + getBody());
+            TestLogger.log("Post completed. Response body: " + getBody());
 
             int statusCode = response.getStatusLine().getStatusCode();
             String body = EntityUtils.toString(response.getEntity());
             parseResponse(body);
 
             if (expectedStatusCode < 400 && StringUtils.isNotBlank(getExceptionMessage()))
-                log("Unexpected error message: " + getExceptionMessage());
+                TestLogger.log("Unexpected error message: " + getExceptionMessage());
 
             assertEquals("Unexpected response status", expectedStatusCode, statusCode);
             return response;

--- a/test/src/org/labkey/test/commands/response/SubmitResponseCommand.java
+++ b/test/src/org/labkey/test/commands/response/SubmitResponseCommand.java
@@ -57,7 +57,8 @@ public class SubmitResponseCommand extends ResponseCommand
 
     private final static String SURVEY_METADATA_FORMAT = "  \"metadata\": { \n" +
             "      \"activityId\": \"%1$s\", \n" +
-            "      \"version\": \"%2$s\" \n" +
+            "      \"version\": \"%2$s\", \n" +
+            "      \"language\": \"%3$s\" \n" +
             "   }, \n";
 
     private String body;
@@ -70,12 +71,13 @@ public class SubmitResponseCommand extends ResponseCommand
         setBody("");
     }
 
-    public SubmitResponseCommand(Consumer<String> logger, String activityId, String version, String appToken, String surveyResponses)
+    public SubmitResponseCommand(Consumer<String> logger, String activityId, String version, String languageCode, String appToken, String surveyResponses)
     {
         setLogger(logger);
-        if (StringUtils.isNotBlank(activityId) || StringUtils.isNotBlank(version))
+        if (StringUtils.isNotBlank(activityId) || StringUtils.isNotBlank(version) || StringUtils.isNotBlank(languageCode))
         {
-            String metadata = String.format(SURVEY_METADATA_FORMAT, StringUtils.defaultString(activityId, ""), StringUtils.defaultString(version,""));
+            String metadata = String.format(SURVEY_METADATA_FORMAT, StringUtils.defaultString(activityId, ""),
+                StringUtils.defaultString(version,""), StringUtils.defaultString(languageCode,""));
             setBody(String.format(BODY_JSON_FORMAT, metadata, appToken, surveyResponses));
         }
         else
@@ -85,7 +87,7 @@ public class SubmitResponseCommand extends ResponseCommand
 
     public SubmitResponseCommand(Consumer<String> logger, Survey survey)
     {
-        this(logger, survey.getActivityId(), survey.getVersion(), survey.getAppToken(), survey.getResponseJson());
+        this(logger, survey.getActivityId(), survey.getVersion(), null, survey.getAppToken(), survey.getResponseJson());
     }
 
     public boolean getLogRequest()

--- a/test/src/org/labkey/test/commands/response/SubmitResponseCommand.java
+++ b/test/src/org/labkey/test/commands/response/SubmitResponseCommand.java
@@ -22,6 +22,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.data.response.Survey;
+import org.labkey.test.util.TestLogger;
 
 import java.util.function.Consumer;
 
@@ -65,15 +66,13 @@ public class SubmitResponseCommand extends ResponseCommand
     private boolean _logRequest = false;
     private String targetUrl = WebTestHelper.buildURL(CONTROLLER_NAME, ACTION_NAME);
 
-    public SubmitResponseCommand(Consumer<String> logger)
+    public SubmitResponseCommand()
     {
-        setLogger(logger);
         setBody("");
     }
 
-    public SubmitResponseCommand(Consumer<String> logger, String activityId, String version, String languageCode, String appToken, String surveyResponses)
+    public SubmitResponseCommand(String activityId, String version, String languageCode, String appToken, String surveyResponses)
     {
-        setLogger(logger);
         if (StringUtils.isNotBlank(activityId) || StringUtils.isNotBlank(version) || StringUtils.isNotBlank(languageCode))
         {
             String metadata = String.format(SURVEY_METADATA_FORMAT, StringUtils.defaultString(activityId, ""),
@@ -87,7 +86,7 @@ public class SubmitResponseCommand extends ResponseCommand
 
     public SubmitResponseCommand(Consumer<String> logger, Survey survey)
     {
-        this(logger, survey.getActivityId(), survey.getVersion(), null, survey.getAppToken(), survey.getResponseJson());
+        this(survey.getActivityId(), survey.getVersion(), null, survey.getAppToken(), survey.getResponseJson());
     }
 
     public boolean getLogRequest()
@@ -108,9 +107,9 @@ public class SubmitResponseCommand extends ResponseCommand
             post.setEntity(new StringEntity(getBody(), ContentType.APPLICATION_JSON));
 
         if (getLogRequest())
-            log("Request body:\n\n" + getBody() + "\n\n");
+            TestLogger.log("Request body:\n\n" + getBody() + "\n\n");
 
-        log("Posting response to LabKey");
+        TestLogger.log("Posting response to LabKey");
         return execute(post, expectedStatusCode);
     }
 

--- a/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.test.commands.response;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.labkey.test.WebTestHelper;
@@ -59,8 +58,7 @@ public class WithdrawParticipantCommand extends ResponseCommand
     {
         Map<String, String> params = new HashMap<>();
         params.put("delete", String.valueOf(getDelete()));
-        if (StringUtils.isNotBlank(getParticipantId()))
-            params.put("participantId", getParticipantId());
+        params.put("participantId", getParticipantId());
         return WebTestHelper.buildURL(CONTROLLER_NAME, ACTION_NAME, params);
     }
 

--- a/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
@@ -28,7 +28,6 @@ import java.util.Map;
 public class WithdrawParticipantCommand extends ResponseCommand
 {
     private static final String APP_TOKEN_JSON_FIELD = "appToken";
-    protected static final String CONTROLLER_NAME = ResponseCommand.CONTROLLER_NAME;
     protected static final String ACTION_NAME = "withdrawfromstudy";
 
     private String _participantId;

--- a/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/WithdrawParticipantCommand.java
@@ -22,7 +22,6 @@ import org.labkey.test.WebTestHelper;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Consumer;
 
 /**
  * Created by RyanS on 1/23/2017.
@@ -36,11 +35,10 @@ public class WithdrawParticipantCommand extends ResponseCommand
     private String _participantId;
     private Boolean _delete;
 
-    public WithdrawParticipantCommand(String participantId, Boolean delete, Consumer<String> logger)
+    public WithdrawParticipantCommand(String participantId, Boolean delete)
     {
         _participantId = participantId;
         _delete = delete;
-        setLogger(logger);
     }
 
     public void setParticipantId(String participantId)

--- a/test/src/org/labkey/test/pages/response/ResponseQueryPage.java
+++ b/test/src/org/labkey/test/pages/response/ResponseQueryPage.java
@@ -46,7 +46,7 @@ public class ResponseQueryPage extends LabKeyPage
         Error("Error Message"),
         Status("Status");
 
-        private String _columnLabel;
+        private final String _columnLabel;
 
         public String getLabel()
         {
@@ -106,7 +106,7 @@ public class ResponseQueryPage extends LabKeyPage
         filterByAppToken(appToken);
 
         DataRegionTable table = new DataRegionTable("query", getDriver());
-        List statusValues = table.getColumnDataAsText(ColumnNames.Status.toString());
+        List<String> statusValues = table.getColumnDataAsText(ColumnNames.Status.toString());
         assertEquals("Unexpected number of requests", submissionCount, statusValues.size());
         assertEquals("Unexpected number of successfully processed requests", successfulProcessingExpected, Collections.frequency(statusValues, "PROCESSED"));
         assertEquals("Unexpected number of unsuccessful requests", submissionCount - successfulProcessingExpected, Collections.frequency(statusValues, "ERROR"));
@@ -122,7 +122,7 @@ public class ResponseQueryPage extends LabKeyPage
         filterByAppToken(appToken);
 
         DataRegionTable table = new DataRegionTable("query", getDriver());
-        List statusValues = table.getColumnDataAsText(ColumnNames.Status.toString());
+        List<String> statusValues = table.getColumnDataAsText(ColumnNames.Status.toString());
         assertEquals("Unexpected number of requests", submissionCount, statusValues.size());
         assertEquals("Unexpected number of unsuccessful requests", submissionCount, Collections.frequency(statusValues, "ERROR"));
         table.clearAllFilters(ColumnNames.AppToken.toString());

--- a/test/src/org/labkey/test/pages/response/ResponseQueryPage.java
+++ b/test/src/org/labkey/test/pages/response/ResponseQueryPage.java
@@ -41,6 +41,7 @@ public class ResponseQueryPage extends LabKeyPage
         AppToken("App Token"),
         SurveyVersion("Survey Version"),
         ActivityId("Activity Id"),
+        Language("Language"),
         Processed("Processed"),
         ProcessedBy("Processed By"),
         Error("Error Message"),
@@ -144,6 +145,12 @@ public class ResponseQueryPage extends LabKeyPage
     {
         DataRegionTable table = new DataRegionTable("query", getDriver());
         return table.getColumnDataAsText(ColumnNames.Status.toString());
+    }
+
+    public Collection<String> getLanguages()
+    {
+        DataRegionTable table = new DataRegionTable("query", getDriver());
+        return table.getColumnDataAsText(ColumnNames.Language.toString());
     }
 
     public class SuccessfulReprocessingMessage extends Message

--- a/test/src/org/labkey/test/tests/response/BaseResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/BaseResponseTest.java
@@ -104,7 +104,7 @@ public abstract class BaseResponseTest extends BaseWebDriverTest implements Post
     String getNewAppToken(String project, String studyShortName, String batchToken)
     {
         log("Requesting app token for project [" + project +"] and study [" + studyShortName + "]");
-        EnrollParticipantCommand cmd = new EnrollParticipantCommand(project, studyShortName, batchToken, "true", this::log);
+        EnrollParticipantCommand cmd = new EnrollParticipantCommand(project, studyShortName, batchToken, "true");
 
         cmd.execute(200);
         String appToken = cmd.getAppToken();

--- a/test/src/org/labkey/test/tests/response/BaseResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/BaseResponseTest.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.json.simple.JSONObject;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
@@ -230,22 +229,6 @@ public abstract class BaseResponseTest extends BaseWebDriverTest implements Post
         command.setParameters(params);
         log("Assigning token: " + token);
         return command.execute(connection, projectName);
-    }
-
-    @BeforeClass
-    public static void doSetup()
-    {
-        BaseResponseTest initTest = (BaseResponseTest) getCurrentTest();
-        initTest.setupProjects();
-    }
-
-    /**
-     * @deprecated This adds unnecessary dependency between test classes.
-     */
-    @Deprecated
-    void setupProjects()
-    {
-        //Do nothing as default, Tests can override if needed
     }
 
     /**

--- a/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
@@ -80,7 +80,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Setting initial state, response txt 1");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, responseString);
         cmd.execute(200);
 
         getMobileAppDataWithRetry("NewSurvey", "lists");
@@ -94,7 +94,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question added. Response text 2");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_2--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "2", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "2", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question added. Response text 2",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -117,7 +117,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed. Response text 3");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_3--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "3", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "3", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding response with single question removed. Response text 3",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -139,7 +139,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with a single question added to group. Response text 4");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_4--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "4", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "4", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with a single question added to group. Response text 4",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -161,7 +161,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed from group. Response text 5");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_5--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "5", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "5", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question removed from group. Response text 5",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -183,7 +183,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question added to sub subgroup. Response text 6");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_6--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "6", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "6", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question added to sub subgroup. Response text 6",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -207,7 +207,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed from sub. Response text 7");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_7--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "7", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "7", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question removed from sub. Response text 7",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -229,7 +229,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single group added. Response text 8");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_8--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "8", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "8", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single group added. Response text 8", 1, getNewRowCount(newSurveyMap, getTableData("NewSurvey")));
@@ -254,7 +254,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with group removed. Response text 9");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_9--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "9", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "9", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with group removed. Response text 9",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -277,7 +277,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_13--RESPONSE.json");
         log("getResponseFromFile(\"DYNAMICSCHEMASTUDY_NewSurvey_13--RESPONSE.json\"): " + responseString);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "13", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "13", null, appToken, responseString);
         cmd.execute(200);
 
         waitForResults(newSurveyGroupedMap, "NewSurveyGroupedList");
@@ -324,7 +324,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_10--RESPONSE.json");
         log("getResponseFromFile(\"DYNAMICSCHEMASTUDY_NewSurvey_10--RESPONSE.json\"): " + responseString);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "10", appToken, responseString); //Schema name in the metadata is: "NewSurvey_Mismatch"
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "10", null, appToken, responseString); //Schema name in the metadata is: "NewSurvey_Mismatch"
         cmd.execute(200);
         sleep(5000); // wait for response shredder to have time to do its work
 
@@ -395,7 +395,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with malformed schema. Response text 11");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_11--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "11", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "11", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         assertEquals("Unexpected new row count in NewSurvey after adding single response with malformed schema. Response text 11",0,getNewRows(newSurveyMap,getTableData("NewSurvey")).size());
@@ -420,7 +420,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with empty schema object. Response text 11");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_empty_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "empty", "1.0", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "empty", "1.0", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         ResponseQueryPage responses = new ResponseQueryPage(this);
@@ -440,7 +440,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with fetalKickCounter active task (FKC-74)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_FKC-74_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "FKC-74", "1.0", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "FKC-74", "1.0", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         List<Map<String, Object>> afterTableData = getTableData("FKC-74counter");
@@ -462,7 +462,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with towerOfHanoi active task (TOH-75)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_TOH-75_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "TOH-75", "1.0", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "TOH-75", "1.0", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(beforeTableData, tableName);
         List<Map<String, Object>> afterTableData = getTableData(tableName);
@@ -484,7 +484,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with spatialSpanMemory active task (SSM-76)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_SSM-76_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "SSM-76", "1.0", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "SSM-76", "1.0", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(beforeTableData, tableName);
         List<Map<String, Object>> afterTableData = getTableData(tableName);
@@ -528,7 +528,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with OtherOption active task (OtherOption)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOption_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOption", "1", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOption", "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -570,7 +570,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting first response with OtherOption for update test");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionUpdate_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "1", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -591,7 +591,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting OtherOption v2 update");
         responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionUpdate_2--RESPONSE.json");
         appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
-        cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "2", appToken, responseString);
+        cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "2", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -613,7 +613,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting first response with OtherOption for empty values test");
         String appToken = getNewAppToken(PROJECT_NAME, STUDY_NAME, null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionBlanks_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, baseTableName, "1", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, baseTableName, "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 

--- a/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
@@ -80,7 +80,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Setting initial state, response txt 1");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, responseString);
         cmd.execute(200);
 
         getMobileAppDataWithRetry("NewSurvey", "lists");
@@ -94,7 +94,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question added. Response text 2");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_2--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "2", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "2", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question added. Response text 2",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -117,7 +117,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed. Response text 3");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_3--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "3", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "3", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding response with single question removed. Response text 3",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -139,7 +139,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with a single question added to group. Response text 4");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_4--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "4", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "4", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with a single question added to group. Response text 4",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -161,7 +161,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed from group. Response text 5");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_5--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "5", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "5", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question removed from group. Response text 5",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -183,7 +183,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question added to sub subgroup. Response text 6");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_6--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "6", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "6", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question added to sub subgroup. Response text 6",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -207,7 +207,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single question removed from sub. Response text 7");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_7--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "7", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "7", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single question removed from sub. Response text 7",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -229,7 +229,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with single group added. Response text 8");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_8--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "8", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "8", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with single group added. Response text 8", 1, getNewRowCount(newSurveyMap, getTableData("NewSurvey")));
@@ -254,7 +254,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with group removed. Response text 9");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_9--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "9", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "9", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(newSurveyMap, "NewSurvey");
         assertEquals("Unexpected new row count in NewSurvey after adding single response with group removed. Response text 9",1,getNewRowCount(newSurveyMap,getTableData("NewSurvey")));
@@ -277,7 +277,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_13--RESPONSE.json");
         log("getResponseFromFile(\"DYNAMICSCHEMASTUDY_NewSurvey_13--RESPONSE.json\"): " + responseString);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "13", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "13", null, appToken, responseString);
         cmd.execute(200);
 
         waitForResults(newSurveyGroupedMap, "NewSurveyGroupedList");
@@ -324,7 +324,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_10--RESPONSE.json");
         log("getResponseFromFile(\"DYNAMICSCHEMASTUDY_NewSurvey_10--RESPONSE.json\"): " + responseString);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "10", null, appToken, responseString); //Schema name in the metadata is: "NewSurvey_Mismatch"
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "10", null, appToken, responseString); //Schema name in the metadata is: "NewSurvey_Mismatch"
         cmd.execute(200);
         sleep(5000); // wait for response shredder to have time to do its work
 
@@ -395,7 +395,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with malformed schema. Response text 11");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_NewSurvey_11--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "11", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "11", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         assertEquals("Unexpected new row count in NewSurvey after adding single response with malformed schema. Response text 11",0,getNewRows(newSurveyMap,getTableData("NewSurvey")).size());
@@ -420,7 +420,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with empty schema object. Response text 11");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_empty_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "empty", "1.0", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("empty", "1.0", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         ResponseQueryPage responses = new ResponseQueryPage(this);
@@ -440,7 +440,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with fetalKickCounter active task (FKC-74)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_FKC-74_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "FKC-74", "1.0", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("FKC-74", "1.0", null, appToken, responseString);
         cmd.execute(200);
         sleep(5000);
         List<Map<String, Object>> afterTableData = getTableData("FKC-74counter");
@@ -462,7 +462,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with towerOfHanoi active task (TOH-75)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_TOH-75_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "TOH-75", "1.0", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("TOH-75", "1.0", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(beforeTableData, tableName);
         List<Map<String, Object>> afterTableData = getTableData(tableName);
@@ -484,7 +484,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with spatialSpanMemory active task (SSM-76)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_SSM-76_1.0--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "SSM-76", "1.0", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("SSM-76", "1.0", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(beforeTableData, tableName);
         List<Map<String, Object>> afterTableData = getTableData(tableName);
@@ -528,7 +528,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting response with OtherOption active task (OtherOption)");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOption_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOption", "1", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("OtherOption", "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -570,7 +570,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting first response with OtherOption for update test");
         String appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionUpdate_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "1", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand("OtherOptionUpdate", "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -591,7 +591,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting OtherOption v2 update");
         responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionUpdate_2--RESPONSE.json");
         appToken = getNewAppToken(PROJECT_NAME,STUDY_NAME,null);
-        cmd = new SubmitResponseCommand(this::log, "OtherOptionUpdate", "2", null, appToken, responseString);
+        cmd = new SubmitResponseCommand("OtherOptionUpdate", "2", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 
@@ -613,7 +613,7 @@ public class DynamicSchemaTest extends BaseResponseTest
         log("Submitting first response with OtherOption for empty values test");
         String appToken = getNewAppToken(PROJECT_NAME, STUDY_NAME, null);
         String responseString = getResponseFromFile("DYNAMICSCHEMASTUDY_OtherOptionBlanks_1--RESPONSE.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, baseTableName, "1", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(baseTableName, "1", null, appToken, responseString);
         cmd.execute(200);
         waitForResults(baseTableData, baseTableName);
 

--- a/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
+++ b/test/src/org/labkey/test/tests/response/DynamicSchemaTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.response;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
@@ -57,8 +58,15 @@ public class DynamicSchemaTest extends BaseResponseTest
         return PROJECT_NAME;
     }
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        DynamicSchemaTest init = (DynamicSchemaTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         //Setup a study
         _containerHelper.deleteProject(PROJECT_NAME, false);

--- a/test/src/org/labkey/test/tests/response/EnrollmentTokensTest.java
+++ b/test/src/org/labkey/test/tests/response/EnrollmentTokensTest.java
@@ -17,7 +17,7 @@
 package org.labkey.test.tests.response;
 
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
@@ -30,17 +30,18 @@ import java.util.Map;
 @Category({Git.class})
 public class EnrollmentTokensTest extends BaseResponseTest
 {
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        EnrollmentTokensTest init = (EnrollmentTokensTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         _containerHelper.createProject(getProjectName(), null);
         _containerHelper.enableModule("Response");
-    }
-
-    @Before
-    public void preTest()
-    {
-        goToProjectHome();
     }
 
     @Test

--- a/test/src/org/labkey/test/tests/response/ErrorLocalizationTest.java
+++ b/test/src/org/labkey/test/tests/response/ErrorLocalizationTest.java
@@ -1,0 +1,103 @@
+package org.labkey.test.tests.response;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.labkey.test.TestTimeoutException;
+import org.labkey.test.categories.Git;
+import org.labkey.test.commands.response.EnrollParticipantCommand;
+import org.labkey.test.components.response.MyStudiesResponseServerTab;
+import org.labkey.test.pages.response.SetupPage;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.labkey.test.commands.response.EnrollmentTokenValidationCommand.TOKEN_REQUIRED;
+
+@Category({Git.class})
+public class ErrorLocalizationTest extends BaseResponseTest
+{
+    private static final String STUDY_ID = "ErrorLocalizationTest";
+
+    private static final String NO_TOKEN_EN = TOKEN_REQUIRED;
+    private static final String NO_TOKEN_SP = "Se requiere un token";
+
+    @Override
+    protected void doCleanup(boolean afterTest) throws TestTimeoutException
+    {
+        super.doCleanup(afterTest);
+    }
+
+    @BeforeClass
+    public static void setupProject()
+    {
+        ErrorLocalizationTest init = (ErrorLocalizationTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
+    {
+        _containerHelper.createProject(getProjectName(), FOLDER_TYPE);
+        MyStudiesResponseServerTab myStudiesResponseServerTab = MyStudiesResponseServerTab.beginAt(this, getProjectName());
+        myStudiesResponseServerTab.setInputId(STUDY_ID);
+        myStudiesResponseServerTab.saveAndExpectSuccess();
+        SetupPage.beginAt(this, getProjectName())
+                .getTokenBatchesWebPart()
+                .openNewBatchPopup()
+                .createNewBatch("10");
+    }
+
+    @Test
+    public void testEnrollWithNoToken()
+    {
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand(getProjectName(), STUDY_ID, null, "NA");
+        enrollCmd.execute(400);
+        checker().verifyEquals("Error message with no language specified.", NO_TOKEN_EN, enrollCmd.getExceptionMessage());
+
+        enrollCmd = new EnrollParticipantCommand(getProjectName(), STUDY_ID, null, "NA");
+        enrollCmd.setLanguage("en");
+        enrollCmd.execute(400);
+        checker().verifyEquals("Error message with english specified.", NO_TOKEN_EN, enrollCmd.getExceptionMessage());
+
+        enrollCmd = new EnrollParticipantCommand(getProjectName(), STUDY_ID, null, "NA");
+        enrollCmd.setLanguage("es");
+        enrollCmd.execute(400);
+        checker().verifyEquals("Error message with spanish specified.", NO_TOKEN_SP, enrollCmd.getExceptionMessage());
+
+        enrollCmd = new EnrollParticipantCommand(getProjectName(), STUDY_ID, null, "NA");
+        enrollCmd.setLanguage("fr");
+        enrollCmd.execute(400);
+        checker().verifyEquals("Error message with unsupported language specified.", NO_TOKEN_EN, enrollCmd.getExceptionMessage());
+
+        enrollCmd = new EnrollParticipantCommand(getProjectName(), STUDY_ID, null, "NA");
+        enrollCmd.setLanguage("xyz");
+        enrollCmd.execute(400);
+        checker().verifyEquals("Error message with nonexistent language specified.", NO_TOKEN_EN, enrollCmd.getExceptionMessage());
+
+    }
+
+    @Test
+    public void testValidateEnrollmentToken()
+    {
+        // Test code
+    }
+
+    @Override
+    protected BrowserType bestBrowser()
+    {
+        return BrowserType.CHROME;
+    }
+
+    @Override
+    protected String getProjectName()
+    {
+        return "ErrorLocalizationTest Project";
+    }
+
+    @Override
+    public List<String> getAssociatedModules()
+    {
+        return Arrays.asList("Response");
+    }
+}

--- a/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
@@ -19,6 +19,7 @@ import com.google.common.net.MediaType;
 import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -144,8 +145,15 @@ public class ForwardResponseTest extends BaseResponseTest
         addRequestMatcher(mockServer, requestPath, log, "POST", MOCKSERVER_CALL_MATCHER_CLASS);
     }
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        ForwardResponseTest init = (ForwardResponseTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         setupProject(STUDY_NAME01, PROJECT_NAME01, SURVEY_NAME, true);
         setupProject(STUDY_NAME02, PROJECT_NAME02, SURVEY_NAME, true);

--- a/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
@@ -362,7 +362,7 @@ public class ForwardResponseTest extends BaseResponseTest
     private String submitResponse(String projectName, String studyName, String batchtoken)
     {
         String appToken = getNewAppToken(projectName, studyName, batchtoken);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 

--- a/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/ForwardResponseTest.java
@@ -362,7 +362,7 @@ public class ForwardResponseTest extends BaseResponseTest
     private String submitResponse(String projectName, String studyName, String batchtoken)
     {
         String appToken = getNewAppToken(projectName, studyName, batchtoken);
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 

--- a/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
+++ b/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
@@ -354,7 +354,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
         String token2 = tokenListPage.getToken(1);
 
         log("Token validation action: successful token request");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME02, STUDY_NAME02, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME02, STUDY_NAME02, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
         Collection<ParticipantProperty> preenrollmentProperties = cmd.getPreEnrollmentParticipantProperties();
@@ -403,7 +403,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
         MyStudiesResponseServerTab myStudiesResponseServerTab = MyStudiesResponseServerTab.beginAt(this);
         myStudiesResponseServerTab.clickUpdateMetadata();  //Should load OriginalParticipantProperty.json
 
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
         Collection<ParticipantProperty> preenrollmentProperties = cmd.getPreEnrollmentParticipantProperties();
@@ -428,7 +428,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
         MyStudiesResponseServerTab myStudiesResponseServerTab = MyStudiesResponseServerTab.beginAt(this);
         myStudiesResponseServerTab.clickUpdateMetadata();  //Should load OriginalParticipantProperty.json
 
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
         Collection<ParticipantProperty> preenrollmentProperties = cmd.getPreEnrollmentParticipantProperties();
@@ -467,7 +467,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
 
         String appToken = getNewAppToken(project, study, token);
         String responseString = getResponseFromFile("ParticipantPropertiesMetadata", "Survey_Response.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_UPDATE_PATH, "1", null, appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_UPDATE_PATH, "1", null, appToken, responseString);
         cmd.execute(200); //Should load AddParticipantProperty.json
 
         TokenListPage tokenListPage = TokenListPage.beginAt(this, project);
@@ -482,7 +482,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
 
     private void verifyAddColumn(String project, String study, String token)
     {
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
         Collection<ParticipantProperty> preenrollmentProperties = cmd.getPreEnrollmentParticipantProperties();
@@ -516,7 +516,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
     {
         //Verify base setup
         log("Token validation action: successful token request");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, enrollmentToken, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(project, study, enrollmentToken);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
         Collection<ParticipantProperty> preenrollmentProperties = cmd.getPreEnrollmentParticipantProperties();
@@ -527,7 +527,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
 
     private void checkParticipantWithdrawal(String token, String appToken, boolean delete, String deleteMessage)
     {
-        WithdrawParticipantCommand withdrawalCmd = new WithdrawParticipantCommand(appToken, delete, this::log);
+        WithdrawParticipantCommand withdrawalCmd = new WithdrawParticipantCommand(appToken, delete);
         withdrawalCmd.execute(200);
 
         goToProjectHome(PROJECT_NAME02);

--- a/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
+++ b/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
@@ -5,6 +5,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -93,8 +94,15 @@ public class ParticipantPropertiesTest extends BaseResponseTest
     }
     protected static ClientAndServer mockServer = null;
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        ParticipantPropertiesTest init = (ParticipantPropertiesTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         initMockserver();
         setupProject(STUDY_NAME01, PROJECT_NAME01, null, true);

--- a/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
+++ b/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
@@ -467,7 +467,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
 
         String appToken = getNewAppToken(project, study, token);
         String responseString = getResponseFromFile("ParticipantPropertiesMetadata", "Survey_Response.json");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_UPDATE_PATH, "1", appToken, responseString);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_UPDATE_PATH, "1", null, appToken, responseString);
         cmd.execute(200); //Should load AddParticipantProperty.json
 
         TokenListPage tokenListPage = TokenListPage.beginAt(this, project);

--- a/test/src/org/labkey/test/tests/response/ReadResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/ReadResponseTest.java
@@ -654,7 +654,7 @@ public class ReadResponseTest extends BaseResponseTest
     @Test
     public void validateExecuteSqlBasic() throws CommandException, IOException
     {
-        Long participantId = ReadResponseTest.participantWithMultipleRow.getId();
+        long participantId = ReadResponseTest.participantWithMultipleRow.getId();
         String participantAppToken = ReadResponseTest.participantWithMultipleRow.getAppToken();
         String sql = "select * from TestListDiffDataTypes";
 
@@ -865,7 +865,7 @@ public class ReadResponseTest extends BaseResponseTest
     }
 
     @Test
-    public void validateExecuteSqlErrorConditions() throws IOException
+    public void validateExecuteSqlErrorConditions()
     {
         final String ERROR_NO_PARTICIPANTID = "ParticipantId not included in request";
         final String ERROR_TABLE_NOT_FOUND = "Query or table not found: core.Users";

--- a/test/src/org/labkey/test/tests/response/ResponseProcessingTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseProcessingTest.java
@@ -576,7 +576,7 @@ public class ResponseProcessingTest extends BaseResponseTest
         click(Locator.linkWithText(SURVEY_NAME));
         assertBlankValue(skipToken, fieldHeader, "Invalid skipped value");
         assertBlankValue(nullToken, fieldHeader, "Invalid null value");
-        assertSubmittedValue(valToken, fieldHeader, "Submitted value not present", String.valueOf(value));
+        assertSubmittedValue(valToken, fieldHeader, "Submitted value not present", value);
         assertBlankValue(emptyToken, fieldHeader, "Invalid empty string value");
         assertBlankValue(wsToken, fieldHeader, "Invalid whitespace string value");
         assertSubmittedValue(dateToken, fieldHeader, "Date value not treated as string", String.valueOf(dateVal));
@@ -708,7 +708,7 @@ public class ResponseProcessingTest extends BaseResponseTest
         checkExpectedErrors(1);
     }
 
-    private void assertExpectedValueCount(List list, String value, int rowCount)
+    private void assertExpectedValueCount(List<String> list, String value, int rowCount)
     {
         assertEquals("Value [\"" + value +"\"] found an unexpected number of times", rowCount, Collections.frequency(list, value));
     }
@@ -833,8 +833,7 @@ public class ResponseProcessingTest extends BaseResponseTest
         table.getCustomizeView().addFilter("ParticipantId/AppToken", "Equals", appToken);
         table.getCustomizeView().applyCustomView(WAIT_FOR_PAGE);
 
-
-        List values = table.getColumnDataAsText("MedName");
+        List<String> values = table.getColumnDataAsText("MedName");
         assertEquals("Unexpected number of meds", 5, Collections.frequency(values, "Advil"));
         assertEquals("Unexpected number of meds", 1, Collections.frequency(values, "Tylenol"));
         assertEquals("Unexpected number of meds", 1, Collections.frequency(values, "Aspirin"));
@@ -1038,7 +1037,7 @@ public class ResponseProcessingTest extends BaseResponseTest
 
     private String submitQuestion(QuestionResponse qr, String appToken, int expectedStatusCode)
     {
-        return super.submitQuestion(qr, appToken, SURVEY_NAME, SURVEY_VERSION, 200);
+        return super.submitQuestion(qr, appToken, SURVEY_NAME, SURVEY_VERSION, expectedStatusCode);
     }
 }
 

--- a/test/src/org/labkey/test/tests/response/ResponseProcessingTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseProcessingTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.response;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.Locator;
@@ -62,8 +63,15 @@ public class ResponseProcessingTest extends BaseResponseTest
         return PROJECT_NAME01;
     }
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        ResponseProcessingTest init = (ResponseProcessingTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         //Setup a study
         _containerHelper.createProject(PROJECT_NAME01, FOLDER_TYPE);

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -15,6 +15,7 @@
  */
 package org.labkey.test.tests.response;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
@@ -48,8 +49,15 @@ public class ResponseSubmissionTest extends BaseResponseTest
         return null;
     }
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        ResponseSubmissionTest init = (ResponseSubmissionTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         doCleanup(false);
 

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -68,7 +68,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         //Scenarios
         //        1. request body not present
         log("Testing bad request body");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log);
+        SubmitResponseCommand cmd = new SubmitResponseCommand();
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
@@ -84,14 +84,14 @@ public class ResponseSubmissionTest extends BaseResponseTest
         int expectedErrorCount = 0;
         //        2. AppToken not present
         log("Testing AppToken not present");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, "", BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, "", BASE_RESULTS);
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.PARTICIPANTID_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //        3. Invalid AppToken Participant
         log("Testing invalid apptoken");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, "INVALIDPARTICIPANTID", BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, "INVALIDPARTICIPANTID", BASE_RESULTS);
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
@@ -113,21 +113,21 @@ public class ResponseSubmissionTest extends BaseResponseTest
         //        4. Invalid Metadata
         //            A. Metadata element missing
         log("Testing Metadata element not present");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, null, null, null, appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(null, null, null, appToken, BASE_RESULTS);
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //            B. Survey Version
         log("Testing SurveyVersion not present");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, null, null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, null, null, appToken, BASE_RESULTS);
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.SURVEYVERSION_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //            C. Survey ActivityId
         log("Testing ActivityId not present");
-        cmd = new SubmitResponseCommand(this::log, null, "1", null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(null, "1", null, appToken, BASE_RESULTS);
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.ACTIVITYID_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
@@ -144,7 +144,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         checkErrors();
         //        5. Response not present
         log("Testing Response element not present");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log);
+        SubmitResponseCommand cmd = new SubmitResponseCommand();
         cmd.setBody(String.format(SubmitResponseCommand.MISSING_RESPONSE_JSON_FORMAT, SURVEY_NAME, "1", appToken));
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.RESPONSE_MISSING_MESSAGE, cmd.getExceptionMessage());
@@ -168,7 +168,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         checkErrors();
         //        6. Study not collecting
         log("Testing Response Submission with Study collection turned off");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(400);
         assertTrue("Unexpected error message: " + cmd.getExceptionMessage(), String.format(SubmitResponseCommand.COLLECTION_DISABLED_MESSAGE_FORMAT, STUDY_NAME01)
                 .equalsIgnoreCase(cmd.getExceptionMessage()));
@@ -185,22 +185,22 @@ public class ResponseSubmissionTest extends BaseResponseTest
 
         log("Testing Response Submission with Study collection turned on. Also testing language capture.");
         // Language: unspecified, which should result in English (US)
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 
         // Language: English (US)
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", "en", appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", "en", appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 
         // Language: Spanish
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", "es", appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", "es", appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 
         // Language: French
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", "fr", appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", "fr", appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
 
@@ -218,7 +218,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
 
         //        8. Test submitting to a Study previously collecting, but not currently accepting results
         log("Testing Response Submission with Study collection turned off after previously being on");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(400);
         assertTrue("Unexpected error message: " + cmd.getExceptionMessage(), String.format(SubmitResponseCommand.COLLECTION_DISABLED_MESSAGE_FORMAT, STUDY_NAME01)
                 .equalsIgnoreCase(cmd.getExceptionMessage()));
@@ -235,7 +235,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME02, STUDY_NAME02, null);
 
         log("Verifying " + STUDY_NAME02 + " collecting responses.");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         log("Testing submission to root container");
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
@@ -243,7 +243,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
 
         //Submit API call using apptoken associated to original study
         log("Submitting from " + PROJECT_NAME02 + " container");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.changeProjectTarget(PROJECT_NAME02);
         assertNotEquals("Attempting to test container agnostic submission and URL targets are the same", originalUrl, cmd.getTargetURL());
         log("Testing submission to matching container");
@@ -252,7 +252,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
 
         //Submit API call using apptoken associated to original study
         log("Submitting from " + PROJECT_NAME01 + " container");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.changeProjectTarget(PROJECT_NAME01);
         assertNotEquals("Attempting to test container agnostic submission and URL targets are the same", originalUrl, cmd.getTargetURL());
         log("Testing submission to appToken/container mismatch");
@@ -280,7 +280,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         String appToken = getNewAppToken(PROJECT_NAME03, STUDY_NAME03, null);
 
         log("Verifying Response Submission prior to study deletion");
-        SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
+        SubmitResponseCommand cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS);
         cmd.execute(200);
         assertTrue("Submission failed, expected success", cmd.getSuccess());
         log("successful submission to " + STUDY_NAME03);
@@ -291,7 +291,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         //Submit API call using appToken associated to deleted study
         checkErrors();
         log("Verifying Response Submission after study deletion");
-        cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS );
+        cmd = new SubmitResponseCommand(SURVEY_NAME, "1", null, appToken, BASE_RESULTS );
         cmd.execute(400);
         assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);

--- a/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
+++ b/test/src/org/labkey/test/tests/response/ResponseSubmissionTest.java
@@ -70,7 +70,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         log("Testing bad request body");
         SubmitResponseCommand cmd = new SubmitResponseCommand(this::log);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
     }
 
@@ -86,14 +86,14 @@ public class ResponseSubmissionTest extends BaseResponseTest
         log("Testing AppToken not present");
         SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, "", BASE_RESULTS);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.PARTICIPANTID_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.PARTICIPANTID_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //        3. Invalid AppToken Participant
         log("Testing invalid apptoken");
         cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, "INVALIDPARTICIPANTID", BASE_RESULTS);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         checkExpectedErrors(expectedErrorCount);
@@ -115,21 +115,21 @@ public class ResponseSubmissionTest extends BaseResponseTest
         log("Testing Metadata element not present");
         SubmitResponseCommand cmd = new SubmitResponseCommand(this::log, null, null, null, appToken, BASE_RESULTS);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.METADATA_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //            B. Survey Version
         log("Testing SurveyVersion not present");
         cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, null, null, appToken, BASE_RESULTS);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.SURVEYVERSION_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.SURVEYVERSION_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         //            C. Survey ActivityId
         log("Testing ActivityId not present");
         cmd = new SubmitResponseCommand(this::log, null, "1", null, appToken, BASE_RESULTS);
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.ACTIVITYID_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.ACTIVITYID_MISSING_MESSAGE, cmd.getExceptionMessage());
         expectedErrorCount++;
 
         checkExpectedErrors(expectedErrorCount);
@@ -147,7 +147,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         SubmitResponseCommand cmd = new SubmitResponseCommand(this::log);
         cmd.setBody(String.format(SubmitResponseCommand.MISSING_RESPONSE_JSON_FORMAT, SURVEY_NAME, "1", appToken));
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.RESPONSE_MISSING_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.RESPONSE_MISSING_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
     }
 
@@ -293,7 +293,7 @@ public class ResponseSubmissionTest extends BaseResponseTest
         log("Verifying Response Submission after study deletion");
         cmd = new SubmitResponseCommand(this::log, SURVEY_NAME, "1", null, appToken, BASE_RESULTS );
         cmd.execute(400);
-        assertEquals("Unexpected error message: " + cmd.getExceptionMessage(), SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
+        assertEquals("Unexpected error message", SubmitResponseCommand.NO_PARTICIPANT_MESSAGE, cmd.getExceptionMessage());
         checkExpectedErrors(1);
     }
 

--- a/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.response;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.CommandException;
@@ -95,8 +96,15 @@ public class SharedStudyIdTest extends BaseResponseTest
         }
     }
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        SharedStudyIdTest init = (SharedStudyIdTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         _containerHelper.deleteProject(CLIENT_1_PROJECT_NAME, false);
         _containerHelper.deleteProject(CLIENT_2_PROJECT_NAME, false);

--- a/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
@@ -36,8 +36,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -131,7 +131,7 @@ public class SharedStudyIdTest extends BaseResponseTest
         assertEquals("Study name not saved for second project", SHORT_NAME.toUpperCase(), myStudiesResponseServerTab.getInputId());
 
         log("Testing enrollment, which should fail without any tokens.");
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", SHORT_NAME, null, "NA", this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", SHORT_NAME, null, "NA");
         enrollCmd.execute(400);
         assertFalse("Enrollment should fail when two projects share a study id but have no enrollment tokens", enrollCmd.getSuccess());
     }
@@ -145,13 +145,13 @@ public class SharedStudyIdTest extends BaseResponseTest
         TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
         String token = tokenListPage.getToken(0);
 
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation for " + CLIENT_1_TOKEN_STUDY + " failed when it shouldn't have", cmd.getSuccess());
 
         tokenListPage = TokenListPage.beginAt(this, CLIENT_2_TOKEN_STUDY);
         token = tokenListPage.getToken(0);
-        cmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
+        cmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation for " + CLIENT_2_TOKEN_STUDY + " failed when it shouldn't have", cmd.getSuccess());
     }
@@ -164,19 +164,19 @@ public class SharedStudyIdTest extends BaseResponseTest
         TokenListPage tokenListPage = TokenListPage.beginAt(this, CLIENT_1_TOKEN_STUDY);
         String token = tokenListPage.getToken(0);
 
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "true", this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "true");
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token + "' for " + CLIENT_1_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());
-        EnrollmentTokenValidationCommand validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
+        EnrollmentTokenValidationCommand validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token);
         validateCmd.execute(400);
         assertFalse("Enrollment token validation for " + CLIENT_1_TOKEN_STUDY + " with token '" + token + "' should fail after enrollment succeeds", validateCmd.getSuccess());
 
         tokenListPage = TokenListPage.beginAt(this, CLIENT_2_TOKEN_STUDY);
         token = tokenListPage.getToken(0);
-        enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "false", this::log);
+        enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token, "false");
         enrollCmd.execute(200);
         assertTrue("Enrollment with token '" + token + "' for  " + CLIENT_2_TOKEN_STUDY + " failed when it shouldn't have", enrollCmd.getSuccess());
-        validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token, this::log);
+        validateCmd = new EnrollmentTokenValidationCommand("home", STUDY_ID, token);
         validateCmd.execute(400);
         assertFalse("Enrollment token validation for " + CLIENT_2_TOKEN_STUDY + " with token '" + token + "' should fail after enrollment succeeds", validateCmd.getSuccess());
     }
@@ -191,7 +191,7 @@ public class SharedStudyIdTest extends BaseResponseTest
         String token3 = tokenListPage.getToken(3);
 
         // test null, blank, and invalid values - all should fail
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token1, null, this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand("home", STUDY_ID, token1, null);
         testRequired(enrollCmd, null);
         testRequired(enrollCmd, "");
         testRequired(enrollCmd, "%20%20%20");

--- a/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
+++ b/test/src/org/labkey/test/tests/response/SharedStudyIdTest.java
@@ -84,8 +84,7 @@ public class SharedStudyIdTest extends BaseResponseTest
         myStudiesResponseServerTab.setInputId(studyId);
         myStudiesResponseServerTab.saveAndExpectSuccess();
 
-        SetupPage setupPage = new SetupPage(this);
-        SetupPage.beginAt(this, projectPath);
+        SetupPage setupPage = SetupPage.beginAt(this, projectPath);
         if (addTokens)
         {
             log("Creating 10 tokens for " + projectPath);

--- a/test/src/org/labkey/test/tests/response/StudyWithdrawTest.java
+++ b/test/src/org/labkey/test/tests/response/StudyWithdrawTest.java
@@ -156,27 +156,27 @@ public class StudyWithdrawTest extends BaseResponseTest
 
         //foreach, validate status update, data deletion, appToken null
         //invalid token
-        WithdrawParticipantCommand command = new WithdrawParticipantCommand("BadToken",false, this::log);
+        WithdrawParticipantCommand command = new WithdrawParticipantCommand("BadToken",false);
         HttpResponse httpResponse = command.execute(400);
         SelectRowsResponse selectResponse = getMobileAppData("Participant");
         //valid token, no delete
         log("withdraw participant " + HRD_KEY + " delete responses");
-        command = new WithdrawParticipantCommand(HAS_RESPONSES_DELETE, true, this::log);
+        command = new WithdrawParticipantCommand(HAS_RESPONSES_DELETE, true);
         command.execute(200);
         //valid token, delete
         log("withdraw participant " + HRND_KEY + " do not delete responses");
-        command = new WithdrawParticipantCommand(HAS_RESPONSES_NO_DELETE, false, this::log);
+        command = new WithdrawParticipantCommand(HAS_RESPONSES_NO_DELETE, false);
         command.execute(200);
         //no data
         log("withdraw participant " + NRD_KEY + " delete responses");
-        command = new WithdrawParticipantCommand(NO_RESPONSES_DELETE, true, this::log);
+        command = new WithdrawParticipantCommand(NO_RESPONSES_DELETE, true);
         command.execute(200);
         //valid token, already withdrawn
         log("withdraw participant " + WT_KEY + " do not delete responses");
-        command = new WithdrawParticipantCommand(WITHDRAWS_TWICE, false, this::log);
+        command = new WithdrawParticipantCommand(WITHDRAWS_TWICE, false);
         command.execute(200);
         log("attempt to withdraw participant " + WT_KEY + " delete responses");
-        command = new WithdrawParticipantCommand(WITHDRAWS_TWICE, true, this::log);
+        command = new WithdrawParticipantCommand(WITHDRAWS_TWICE, true);
         command.execute(400);
 
         //all users except STAYS_IN should no longer be enrolled

--- a/test/src/org/labkey/test/tests/response/StudyWithdrawTest.java
+++ b/test/src/org/labkey/test/tests/response/StudyWithdrawTest.java
@@ -18,6 +18,7 @@ package org.labkey.test.tests.response;
 import org.apache.http.HttpResponse;
 import org.jetbrains.annotations.Nullable;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.remoteapi.query.SelectRowsResponse;
@@ -68,8 +69,15 @@ public class StudyWithdrawTest extends BaseResponseTest
     private static String WT_KEY;
     private static String SI_KEY;
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        StudyWithdrawTest init = (StudyWithdrawTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         _containerHelper.deleteProject(getProjectName(),false);
         _containerHelper.createProject(getProjectName(), FOLDER_TYPE);

--- a/test/src/org/labkey/test/tests/response/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/response/TokenValidationTest.java
@@ -103,7 +103,7 @@ public class TokenValidationTest extends BaseResponseTest
         String token = tokenListPage.getToken(0);
 
         log("Token validation action: successful token request");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, token);
         cmd.execute(200);
         assertTrue("Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
     }
@@ -115,7 +115,7 @@ public class TokenValidationTest extends BaseResponseTest
         String token = tokenListPage.getToken(0);
 
         log("Token validation action: invalid StudyId");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01 + "_INVALIDSTUDYNAME", token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01 + "_INVALIDSTUDYNAME", token);
         cmd.execute(400);
         assertFalse("Enrollment token validation succeeded with an invalid studyId", cmd.getSuccess());
         assertEquals("Unexpected error message", String.format(EnrollmentTokenValidationCommand.INVALID_STUDYID_FORMAT, STUDY_NAME01 + "_INVALIDSTUDYNAME"), cmd.getExceptionMessage());
@@ -128,7 +128,7 @@ public class TokenValidationTest extends BaseResponseTest
         String token = tokenListPage.getToken(0);
 
         log("Token validation action: no StudyId");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, null, token, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, null, token);
         cmd.execute(400);
         assertFalse("Enrollment token validation succeeded without the studyId", cmd.getSuccess());
         assertEquals("Unexpected error message", EnrollmentTokenValidationCommand.BLANK_STUDYID, cmd.getExceptionMessage());
@@ -141,7 +141,7 @@ public class TokenValidationTest extends BaseResponseTest
         String token = tokenListPage.getToken(0);
 
         log("Token validation action: Invalid Token");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, token + "thisIsAnInvalidToken", this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, token + "thisIsAnInvalidToken");
         cmd.execute(400);
         assertFalse("Enrollment token validation succeeded when it shouldn't have", cmd.getSuccess());
         assertEquals("Unexpected error message", String.format(EnrollmentTokenValidationCommand.INVALID_TOKEN_FORMAT, token + "thisIsAnInvalidToken".toUpperCase()), cmd.getExceptionMessage());
@@ -151,7 +151,7 @@ public class TokenValidationTest extends BaseResponseTest
     public void testBlankTokenWBatch()
     {
         log("Token validation action: Invalid Blank Token");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, null, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME01, STUDY_NAME01, null);
         cmd.execute(400);
         assertFalse("Enrollment token validation succeeded when it shouldn't have", cmd.getSuccess());
         assertEquals("Unexpected error message", EnrollmentTokenValidationCommand.TOKEN_REQUIRED, cmd.getExceptionMessage());
@@ -162,7 +162,7 @@ public class TokenValidationTest extends BaseResponseTest
     {
         //Note: This uses the secondary project because once a batch is created blank tokens are no longer accepted
         log("Token validation action: successful blank token request");
-        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME02, STUDY_NAME02, null, this::log);
+        EnrollmentTokenValidationCommand cmd = new EnrollmentTokenValidationCommand(PROJECT_NAME02, STUDY_NAME02, null);
         cmd.execute(200);
         assertTrue("Blank Enrollment token validation failed when it shouldn't have", cmd.getSuccess());
     }
@@ -172,7 +172,7 @@ public class TokenValidationTest extends BaseResponseTest
     public void testResolveEnrollmentToken()
     {
         // Always resolve from the /Home project... folder shouldn't matter
-        ResolveEnrollmentTokenCommand resolveCmd = new ResolveEnrollmentTokenCommand("home", null, this::log);
+        ResolveEnrollmentTokenCommand resolveCmd = new ResolveEnrollmentTokenCommand("home", null);
 
         log("Attempt resolving without specifying enrollment token");
         testInvalid(resolveCmd, null, EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
@@ -206,7 +206,7 @@ public class TokenValidationTest extends BaseResponseTest
         assertEquals(STUDY_NAME01, resolveCmd.getStudyId());
 
         log("Enroll and resolve again");
-        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand(PROJECT_NAME01, STUDY_NAME01, goodToken1, "true", this::log);
+        EnrollParticipantCommand enrollCmd = new EnrollParticipantCommand(PROJECT_NAME01, STUDY_NAME01, goodToken1, "true");
         enrollCmd.execute(200);
         resolveCmd.execute(200);
         assertTrue(resolveCmd.getSuccess());

--- a/test/src/org/labkey/test/tests/response/TokenValidationTest.java
+++ b/test/src/org/labkey/test/tests/response/TokenValidationTest.java
@@ -16,6 +16,7 @@
 package org.labkey.test.tests.response;
 
 import org.jetbrains.annotations.Nullable;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.labkey.test.categories.Git;
@@ -48,8 +49,15 @@ public class TokenValidationTest extends BaseResponseTest
     static final String PROJECT_NAME03 = "TokenValidationTest Project 3";
     static final String STUDY_NAME03 = "RESOLVEVALIDATION";
 
-    @Override
-    void setupProjects()
+    @BeforeClass
+    public static void setupProject()
+    {
+        TokenValidationTest init = (TokenValidationTest) getCurrentTest();
+
+        init.doSetup();
+    }
+
+    private void doSetup()
     {
         _containerHelper.deleteProject(PROJECT_NAME01, false);
         _containerHelper.createProject(PROJECT_NAME01, FOLDER_TYPE);
@@ -176,7 +184,7 @@ public class TokenValidationTest extends BaseResponseTest
 
         log("Attempt resolving without specifying enrollment token");
         testInvalid(resolveCmd, null, EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
-        testInvalid(resolveCmd, "   ", EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
+        testInvalid(resolveCmd, "", EnrollmentTokenValidationCommand.TOKEN_REQUIRED);
 
         log("Attempt resolving a couple invalid tokens");
         String badToken = "ABCDEFGH"; // Wrong format - too short


### PR DESCRIPTION
#### Rationale
We want the Response server to support multi-language studies, starting with Spanish. https://docs.google.com/document/d/1Zt4pY1EwnBs-jFaT3PsJpGBuyVx95GAINyxCRObdoLg/edit

#### Changes
* Add a language enum to transform two-character language codes ("es", "en") into friendly names ("Spanish", "English (US)")
* Use language parameter to determine error message translation in enrollment APIs
* Tunnel response language property through and persist friendly name in new `Response.Language` column
* Add test that submits responses tagged with three different languages and verifies friendly name presence in the Response table
* Add test for localized error message