### PR TITLE
Improve bookkeeping around forwarding containers

### DIFF
--- a/src/org/labkey/response/ResponseManager.java
+++ b/src/org/labkey/response/ResponseManager.java
@@ -90,6 +90,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -1491,14 +1492,18 @@ public class ResponseManager
     }
 
     /**
-     * Get set of containers
-     * @return List of container id strings
+     * Get a set of containers that have MyStudies studies. Some corresponding containers may no longer exist
+     * (e.g., folders deleted when module is not present on a dev machine), so nulls are filtered out.
+     *
+     * @return Set of containers
      */
-    public List<String> getStudyContainers()
+    public Set<Container> getStudyContainers()
     {
         MobileAppStudySchema schema = MobileAppStudySchema.getInstance();
-        TableSelector selector = new TableSelector(schema.getTableInfoStudy(), Collections.singleton("Container"), null, null);
-        return selector.getArrayList(String.class);
+        return new TableSelector(schema.getTableInfoStudy(), Collections.singleton("Container"), null, null).stream(String.class)
+            .map(ContainerManager::getForId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
     }
 
     public String getEnrollmentToken(Container container, Integer participantId)


### PR DESCRIPTION
#### Rationale
Address a couple minor issues with forwarding-enabled container handling:

* Previous code intialized `enabledContainers` to a `ConcurrentHashMap` and then immediately replaced it with the (non-concurrent) `HashMap` coming from `refreshEnabledContainers()`. This change makes `enabledContainers` final and correctly clears & adds to ensure thread safety.
* While not likely on a production system, it's possible to orphan a row in the mobileAppStudy.study table, e.g., delete a MyStudies folder when the Response module is not deployed. I had a local bad database with orphaned rows which then failed server startup. It's simple enough to null check the resolved containers.