### PR TITLE
Update labkeyVersion for standalone build

### DIFF
--- a/init.gradle
+++ b/init.gradle
@@ -2,7 +2,7 @@ allprojects {
     // Properties for standalone build.
     // We define these here, instead of 'gradle.properties' to avoid overwriting properties in a standard build
     ext {
-        labkeyVersion = "21.7-SNAPSHOT"
+        labkeyVersion = "21.11-SNAPSHOT"
 
         buildFromSource = true
 


### PR DESCRIPTION
#### Rationale
Standalone build is currently failing because it is pulling the wrong bits from Artifactory.