### PR TITLE
Sort results from `executeSql`

### DIFF
--- a/test/src/org/labkey/test/tests/response/BaseResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/BaseResponseTest.java
@@ -16,8 +16,8 @@
 package org.labkey.test.tests.response;
 
 import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Assert;
 import org.labkey.remoteapi.Command;
 import org.labkey.remoteapi.CommandException;
 import org.labkey.remoteapi.CommandResponse;
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.Assert.assertEquals;
@@ -334,76 +333,34 @@ public abstract class BaseResponseTest extends BaseWebDriverTest implements Post
 
     protected void checkJsonMapAgainstExpectedValues(Map<String, Object> expectedValues, Map<String, Object> actualValues)
     {
-        Set<String> columns = expectedValues.keySet();
+        List<String> ignoredColumns = List.of(
+                "Key",
+                "Created",
+                "Modified",
+                "lastIndexed",
+                "diImportHash",
+                "EntityId",
+                "_labkeyurl_user");
 
-        for (String column : columns)
+        Map<String, Object> normalizedValues = new HashMap<>();
+        for (String column : actualValues.keySet())
         {
-            Assert.assertTrue("Expected column " + column + " was not in the jsonObject.", actualValues.containsKey(column));
-
-            Object value;
-            if (actualValues.get(column) instanceof Map)
+            if (expectedValues.containsKey(column) || !ignoredColumns.contains(column))
             {
-                // Need to do this if the object that is being compared came from an executeSql call.
-                Map<String, Object> columnMap = (Map<String, Object>)actualValues.get(column);
-                value = columnMap.get("value");
-            }
-            else
-                value = actualValues.get(column);
-
-            log("Validating column '" + column + "' which is a '" + value.getClass().getName() + "' data type.");
-
-            switch(expectedValues.get(column).getClass().getSimpleName())
-            {
-                case "Integer":
-
-                    // There is this odd case where the field is an integer but the json returns a long.
-                    // Not worth worrying about, but will need to account for.
-                    Assert.assertEquals(column + " not as expected.", expectedValues.get(column), ((Number)value).intValue());
-                    break;
-                case "Double":
-                    Assert.assertEquals(column + " not as expected.", Double.parseDouble(expectedValues.get(column).toString()), ((Number)value).doubleValue(), 0.0);
-                    break;
-                case "Number":
-                    Assert.assertEquals(column + " not as expected.", expectedValues.get(column), value);
-                case "Boolean":
-                    if ((boolean)expectedValues.get(column))
-                        Assert.assertTrue(column + " was not true (as expected).",(boolean)value);
-                    else
-                        Assert.assertFalse(column + " was not false (as expected).",(boolean)value);
-                    break;
-                default:
-                    // Long and String are the only types that don't need some kind of special casting.
-                    Assert.assertEquals(column + " not as expected.", expectedValues.get(column), value);
-                    break;
+                Object value;
+                if (actualValues.get(column) instanceof Map columnMap)
+                {
+                    // Need to do this if the object that is being compared came from an executeSql call.
+                    value = columnMap.get("value");
+                }
+                else
+                {
+                    value = actualValues.get(column);
+                }
+                normalizedValues.put(column, value);
             }
         }
-
-        // If we've gotten to this point then we know that all of the expected columns and values were there.
-        // Now we need to check that the jsonObject did not return any unexpected columns.
-        StringBuilder unexpectedJsonColumn = new StringBuilder();
-        boolean pass = true;
-        for (Object jsonColumn : actualValues.keySet())
-        {
-            String column = (String)jsonColumn;
-            // If the query returned all columns there are a few columns to ignore.
-            // Ignore the 'Created', 'Key', 'EntityId', 'lastIndexed' and 'Modified' fields. These fields can be tricky to get an accurate expected value especially the timestamp fields.
-            if ((!expectedValues.containsKey(column)) &&
-                (
-                    !column.equals("Key") &&
-                    !column.equals("Created") &&
-                    !column.equals("Modified") &&
-                    !column.equals("lastIndexed") &&
-                    !column.equals("diImportHash") &&
-                    !column.equals("EntityId") &&
-                    !column.equals("_labkeyurl_user")
-                ))
-            {
-                unexpectedJsonColumn.append("Found unexpected column '").append(column).append("' in jsonObject.\r\n");
-                pass = false;
-            }
-        }
-
-        Assert.assertTrue(unexpectedJsonColumn.toString(), pass);
+        Assertions.assertThat(normalizedValues).as("Row data").containsExactlyInAnyOrderEntriesOf(expectedValues);
     }
 
     protected String getResponseFromFile(String dir, String filename)

--- a/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
+++ b/test/src/org/labkey/test/tests/response/ParticipantPropertiesTest.java
@@ -31,6 +31,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.openqa.selenium.support.ui.FluentWait;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -221,7 +222,7 @@ public class ParticipantPropertiesTest extends BaseResponseTest
         String dateValue = "2019-02-22 00:00:00.000";
         String timeValue = "12:34:56.789";
         Number intValue = 1;
-        Number doubleValue = 1.1;
+        Number doubleValue = BigDecimal.valueOf(1.1);
         boolean booleanValue = true;
 
         Map<String, Object> values = new HashMap<>();

--- a/test/src/org/labkey/test/tests/response/ReadResponseTest.java
+++ b/test/src/org/labkey/test/tests/response/ReadResponseTest.java
@@ -37,6 +37,7 @@ import org.labkey.test.util.APIUserHelper;
 import org.labkey.test.util.TestDataGenerator;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -352,7 +353,7 @@ public class ReadResponseTest extends BaseResponseTest
             expectedValues.put("booleanField", false);
 
         expectedValues.put("integerField", id + FIRST_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + FIRST_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + FIRST_MANTISSA)));
         expectedValues.put("dateTimeField", FIRST_DATE);
         expectedValues.put("flagField", FIRST_FLAG_FIELD + ReadResponseTest.participantWithMultipleRow.getId());
 
@@ -366,7 +367,7 @@ public class ReadResponseTest extends BaseResponseTest
         expectedValues.put("multiLineField", SECOND_MULTILINE_STRING_FIELD.replace("$", Integer.toString(ReadResponseTest.participantWithMultipleRow.getId())));
         expectedValues.put("booleanField", true);
         expectedValues.put("integerField", id + SECOND_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + SECOND_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + SECOND_MANTISSA)));
         expectedValues.put("dateTimeField", SECOND_DATE);
         expectedValues.put("flagField", SECOND_FLAG_FIELD + ReadResponseTest.participantWithMultipleRow.getId());
 
@@ -380,7 +381,7 @@ public class ReadResponseTest extends BaseResponseTest
         expectedValues.put("multiLineField", THIRD_MULTILINE_STRING_FIELD.replace("$", Integer.toString(ReadResponseTest.participantWithMultipleRow.getId())));
         expectedValues.put("booleanField", false);
         expectedValues.put("integerField", id + THIRD_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + THIRD_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(ReadResponseTest.participantWithMultipleRow.getId() + THIRD_MANTISSA)));
         expectedValues.put("dateTimeField", THIRD_DATE);
         expectedValues.put("flagField", THIRD_FLAG_FIELD + ReadResponseTest.participantWithMultipleRow.getId());
 
@@ -425,7 +426,7 @@ public class ReadResponseTest extends BaseResponseTest
             expectedValues.put("booleanField", false);
 
         expectedValues.put("integerField", id + FIRST_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(ReadResponseTest.participantWithOneRow.getId() + FIRST_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(ReadResponseTest.participantWithOneRow.getId() + FIRST_MANTISSA)));
         expectedValues.put("dateTimeField", FIRST_DATE);
         expectedValues.put("flagField", FIRST_FLAG_FIELD + ReadResponseTest.participantWithOneRow.getId());
 
@@ -525,7 +526,7 @@ public class ReadResponseTest extends BaseResponseTest
             expectedValues.put("booleanField", false);
 
         expectedValues.put("integerField", idAsInt + FIRST_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(ReadResponseTest.participantWithOneRow.getId() + FIRST_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(ReadResponseTest.participantWithOneRow.getId() + FIRST_MANTISSA)));
         expectedValues.put("dateTimeField", FIRST_DATE);
         expectedValues.put("flagField", FIRST_FLAG_FIELD + ReadResponseTest.participantWithOneRow.getId());
 
@@ -679,7 +680,7 @@ public class ReadResponseTest extends BaseResponseTest
             expectedValues.put("booleanField", false);
 
         expectedValues.put("integerField", participantId + FIRST_INT_OFFSET);
-        expectedValues.put("doubleField", Double.parseDouble(participantId + FIRST_MANTISSA));
+        expectedValues.put("doubleField", BigDecimal.valueOf(Double.parseDouble(participantId + FIRST_MANTISSA)));
         expectedValues.put("dateTimeField", FIRST_DATE);
         expectedValues.put("flagField", FIRST_FLAG_FIELD + participantId);
 
@@ -735,7 +736,7 @@ public class ReadResponseTest extends BaseResponseTest
         String participantAppToken = ReadResponseTest.participantWithMultipleRow.getAppToken();
 
         log("First validate with a join clause.");
-        String sql = "select SecondSimpleList.integerField, SecondSimpleList.Description, TestListDiffDataTypes.participantId from TestListDiffDataTypes inner join SecondSimpleList on SecondSimpleList.integerField = TestListDiffDataTypes.integerField";
+        String sql = "select SecondSimpleList.integerField, SecondSimpleList.Description, TestListDiffDataTypes.participantId from TestListDiffDataTypes inner join SecondSimpleList on SecondSimpleList.integerField = TestListDiffDataTypes.integerField order by integerField";
         log("Call the executeSql action with sql: '" + sql + "' and participant " + participantId + " (" + participantAppToken + ").");
 
         Map<String, Object> params = new HashMap<>();
@@ -818,7 +819,9 @@ public class ReadResponseTest extends BaseResponseTest
         participantId = ReadResponseTest.participantWithMultipleRow.getId();
         participantAppToken = ReadResponseTest.participantWithMultipleRow.getAppToken();
 
-        sql = "select TestListDiffDataTypes.participantId, ThirdList.integerField, SecondSimpleList.Description from ((TestListDiffDataTypes inner join ThirdList on ThirdList.participantId = TestListDiffDataTypes.participantId) inner join SecondSImpleList on TestListDiffDataTypes.integerField = SecondSimpleList.integerField)";
+        sql = "select TestListDiffDataTypes.participantId, ThirdList.integerField, SecondSimpleList.Description " +
+                "from ((TestListDiffDataTypes inner join ThirdList on ThirdList.participantId = TestListDiffDataTypes.participantId) " +
+                "inner join SecondSImpleList on TestListDiffDataTypes.integerField = SecondSimpleList.integerField) order by integerField";
         log("Call the executeSql action with sql: '" + sql + "' and participant " + participantId + " (" + participantAppToken + "). This participant has no rows in the list.");
         goToProjectHome();
 


### PR DESCRIPTION
#### Rationale
Tests assume that executeSql calls will return rows in a predictable order but they do not. Explicitly adding an `order by` to the SQL makes the test more reliable.
The error messages for these failed row comparisons are also not very informative, showing just one key/value of the comparison mismatch. Using `AssertJ` produces much more informative errors.

#### Related Pull Requests
* N/A

#### Changes
* Add `order by` to test queries
* Update row comparison to produce more informative errors.
