### PR TITLE
Update Gradle plugin to remove dependency on 'internal' module

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Properties for standalone build
-gradlePluginsVersion=1.39.1
+gradlePluginsVersion=1.40.0
 artifactory_contextUrl=https://labkey.jfrog.io/artifactory
 
 apacheTomcatVersion=9.0.70


### PR DESCRIPTION
#### Rationale
`gradlePlugin` v1.39 automatically adds a dependency on the `internal` module, which no longer exists as of LabKey 23.3

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/166

#### Changes
* Update gradle plugin to `1.40.0`