### PR TITLE
Use typed getters to avoid casting

### DIFF
--- a/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
+++ b/test/src/org/labkey/test/commands/response/EnrollParticipantCommand.java
@@ -123,7 +123,7 @@ public class EnrollParticipantCommand extends ResponseCommand
     @Override
     protected void parseSuccessfulResponse(JSONObject response)
     {
-        _appToken = (String) ((JSONObject) response.get("data")).get(APP_TOKEN_JSON_FIELD);
+        _appToken = response.getJSONObject("data").getString(APP_TOKEN_JSON_FIELD);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Spring clean up