### PR TITLE
Avoid unnecessary Gradle task configuration

### DIFF
--- a/distributions/fda/build.gradle
+++ b/distributions/fda/build.gradle
@@ -17,15 +17,12 @@ BuildUtils.addModuleDistributionDependencies(project, [BuildUtils.getApiProjectP
                                                        project.parent.parent.getPath(), // Response module
                                                        BuildUtils.getPlatformModuleProjectPath(project.gradle, "visualization")])
 
-project.task(
-        "distribution",
-        group: GroupNames.DISTRIBUTION,
-        type: ModuleDistribution,
+project.tasks.register("distribution", ModuleDistribution)
         {ModuleDistribution dist ->
+            group GroupNames.DISTRIBUTION
             dist.subDirName='response'
             dist.includeTarGZArchive=true
             dist.extraFileIdentifier='-response'
             dist.simpleDistribution=true
             dist.embeddedArchiveType='tar.gz'
         }
-)


### PR DESCRIPTION
#### Rationale
Using [task configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) can make builds more efficient.

#### Related Pull Requests
* https://github.com/LabKey/gradlePlugin/pull/171

#### Changes
* Update gradle task references to avoid unnecessary configuration