### PR TITLE
Eliminate use of deprecated LimitedUser() method

### DIFF
--- a/src/org/labkey/response/ResponseManager.java
+++ b/src/org/labkey/response/ResponseManager.java
@@ -879,7 +879,7 @@ public class ResponseManager
 
         // if a user isn't provided, need to create a LimitedUser to use for checking permissions, wrapping the Guest user
         User insertUser = new LimitedUser((user == null)? UserManager.getGuestUser() : user,
-                new int[0], Collections.singleton(RoleManager.getRole(SubmitterRole.class)), false);
+                Collections.singleton(RoleManager.getRole(SubmitterRole.class)));
 
         try (DbScope.Transaction transaction = scope.ensureTransaction())
         {
@@ -1304,8 +1304,7 @@ public class ResponseManager
     private void deleteParticipantDataFromSurveyLists(Participant participant) throws Exception
     {
         // Create a LimitedUser to use for checking permissions, wrapping the Guest user
-        User user = new LimitedUser(UserManager.getGuestUser(),
-                new int[0], Collections.singleton(RoleManager.getRole(EditorRole.class)), false);
+        User user = new LimitedUser(UserManager.getGuestUser(), Collections.singleton(RoleManager.getRole(EditorRole.class)));
 
         //Get all lists in the container
         Collection<ListDefinition> lists = ListService.get().getLists(participant.getContainer()).values();

--- a/src/org/labkey/response/SurveyDesignProcessor.java
+++ b/src/org/labkey/response/SurveyDesignProcessor.java
@@ -151,8 +151,7 @@ public class SurveyDesignProcessor extends DynamicListProcessor
             throw new InvalidDesignException(LogMessageFormats.MISSING_METADATA);
 
         // if a user isn't provided, need to create a LimitedUser to use for checking permissions, wrapping the Guest user
-        User insertUser = new LimitedUser((user == null)? UserManager.getGuestUser() : user,
-                new int[0], Collections.singleton(RoleManager.getRole(AuthorRole.class)), false);
+        User insertUser = new LimitedUser((user == null)? UserManager.getGuestUser() : user, Collections.singleton(RoleManager.getRole(AuthorRole.class)));
 
         ListDefinition listDef = ensureList(study.getContainer(), insertUser, design.getSurveyName(), null);
         applySurveyUpdate(study.getContainer(), insertUser, listDef.getDomain(), design.getSteps(), design.getSurveyName(), "");

--- a/src/org/labkey/response/forwarder/SurveyResponseForwardingJob.java
+++ b/src/org/labkey/response/forwarder/SurveyResponseForwardingJob.java
@@ -50,7 +50,7 @@ public class SurveyResponseForwardingJob implements org.quartz.Job, Callable<Str
     {
         if (forwardingUser == null)
         {
-            forwardingUser = new LimitedUser(User.getSearchUser(), new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+            forwardingUser = new LimitedUser(User.getSearchUser(), Collections.singleton(RoleManager.getRole(ReaderRole.class)));
             forwardingUser.setPrincipalType(PrincipalType.SERVICE);
         }
         return forwardingUser;

--- a/src/org/labkey/response/participantproperties/ParticipantPropertiesProcessor.java
+++ b/src/org/labkey/response/participantproperties/ParticipantPropertiesProcessor.java
@@ -123,8 +123,7 @@ public class ParticipantPropertiesProcessor extends DynamicListProcessor
             throw new InvalidDesignException(String.format(LogMessageFormats.DESIGN_STUDYID_MISMATCH, design.getMetadata().getStudyId(), study.getShortName()));
 
         // if a user isn't provided, need to create a LimitedUser to use for checking permissions, wrapping the Guest user
-        User insertUser = new LimitedUser((user == null)? UserManager.getGuestUser() : user,
-                new int[0], Collections.singleton(RoleManager.getRole(AuthorRole.class)), false);
+        User insertUser = new LimitedUser((user == null)? UserManager.getGuestUser() : user, Collections.singleton(RoleManager.getRole(AuthorRole.class)));
 
         String currentVersion = getParticipantPropertiesDesignVersion(user, study.getContainer());
         logger.debug(String.format(LogMessageFormats.START_UPDATE_PARTICIPANT_PROPERTIES, study.getShortName(), currentVersion, design.getStudyVersion()));

--- a/src/org/labkey/response/query/ReadResponsesQuerySchema.java
+++ b/src/org/labkey/response/query/ReadResponsesQuerySchema.java
@@ -91,7 +91,7 @@ public class ReadResponsesQuerySchema extends UserSchema
 
     public static ReadResponsesQuerySchema get(Participant participant)
     {
-        User user = new LimitedUser(User.guest, new int[0], Collections.singleton(RoleManager.getRole(ReaderRole.class)), false);
+        User user = new LimitedUser(User.guest, Collections.singleton(RoleManager.getRole(ReaderRole.class)));
         return new ReadResponsesQuerySchema(user, participant.getContainer(), participant);
     }
 


### PR DESCRIPTION
#### Rationale
Use the simpler constructor that doesn't take an `int[]` parameter.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/4721